### PR TITLE
Feature-24: FileHashStore Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>1.2</version>
-  </dependency>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -35,6 +35,16 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>2.12.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.15.2</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -709,8 +709,8 @@ public class FileHashStore implements HashStore {
         Path targetFilePath = target.toPath();
         try {
             Files.move(sourceFilePath, targetFilePath, StandardCopyOption.ATOMIC_MOVE);
-            logFileHashStore.debug("FileHashStore.move - file moved from: " + sourceFilePath.toString() + ", to: "
-                    + targetFilePath.toString());
+            logFileHashStore.debug("FileHashStore.move - file moved from: " + sourceFilePath + ", to: "
+                    + targetFilePath);
             return true;
         } catch (AtomicMoveNotSupportedException amnse) {
             logFileHashStore.error(

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -77,15 +77,15 @@ public class FileHashStore implements HashStore {
      * accurate. It will only check for an existing configuration, directories or
      * objects before initializing.
      * 
-     * Two directories will be created based on the given storeDirectory string:
-     * - .../objects
-     * - .../objects/tmp
+     * Two directories will be created based on the given storePath string:
+     * - .../[storePath]/objects
+     * - .../[storePath]/objects/tmp
      * 
-     * @param hashstoreProperties HashMap of the HashStore required keys:
-     *                            (Path) storePath,
-     *                            (int) storeDepth,
-     *                            (int) storeWidth
-     *                            (String) storeAlgorithm
+     * @param hashstoreProperties HashMap<String, Object> of the following keys:
+     *                            storePath (Path)
+     *                            storeDepth (int)
+     *                            storeWidth (int)
+     *                            storeAlgorithm String)
      * @throws IllegalArgumentException Constructor arguments cannot be null, empty
      *                                  or less than 0
      * @throws IOException              Issue with creating directories
@@ -136,13 +136,12 @@ public class FileHashStore implements HashStore {
             checkConfigurationEquality("store path", storePath, existingStorePath);
             checkConfigurationEquality("store depth", storeDepth, existingStoreDepth);
             checkConfigurationEquality("store width", storeWidth, existingStoreWidth);
-            checkConfigurationEquality("store algorithm", storeAlgorithm,
-                    existingStoreAlgorithm);
+            checkConfigurationEquality("store algorithm", storeAlgorithm, existingStoreAlgorithm);
 
         } else {
-            // Check if HashStore exists at the given store path (and missing config)
+            // Check if HashStore exists at the given store path (and is missing config)
             logFileHashStore.debug(
-                    "FileHashStore - 'hashstore.yaml' not found, check to see if objects and/or directories exist");
+                    "FileHashStore - 'hashstore.yaml' not found, check store path for objects and directories");
 
             if (Files.exists(storePath)) {
                 boolean hashStoreExists = false;
@@ -262,8 +261,8 @@ public class FileHashStore implements HashStore {
      */
     protected void checkConfigurationEquality(String propertyName, Object suppliedValue, Object existingValue) {
         if (!Objects.equals(suppliedValue, existingValue)) {
-            String errMsg = "FileHashStore - Supplied " + propertyName + ": " + suppliedValue
-                    + " is not equal to the existing configuration: " + existingValue;
+            String errMsg = "FileHashStore.checkConfigurationEquality() - Supplied " + propertyName + ": "
+                    + suppliedValue + " does not match the existing configuration value: " + existingValue;
             logFileHashStore.fatal(errMsg);
             throw new IllegalArgumentException(errMsg);
         }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -167,7 +167,7 @@ public class FileHashStore implements HashStore {
 
             if (Files.exists(storePath)) {
                 try (Stream<Path> walk = Files.walk(storePath)) {
-                    if (walk.anyMatch(Files::exists)) {
+                    if (walk.anyMatch(path -> path != null && Files.exists(path))) {
                         String errMsg = "FileHashStore - Missing 'hashstore.yaml' but HashStore directories and/or objects found";
                         logFileHashStore.fatal(errMsg);
                         throw new IllegalStateException(errMsg);

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -167,16 +167,16 @@ public class FileHashStore implements HashStore {
 
             if (Files.exists(storePath)) {
                 try (Stream<Path> walk = Files.walk(storePath)) {
-                    walk.forEach(path -> {
-                        if (!path.equals(storePath)) {
-                            String errMsg = "FileHashStore - Missing 'hashstore.yaml' but HashStore directories and objects found";
-                            logFileHashStore.fatal(errMsg);
-                            throw new IllegalStateException(errMsg);
-                        }
-                    });
+                    if (walk.anyMatch(Files::exists)) {
+                        String errMsg = "FileHashStore - Missing 'hashstore.yaml' but HashStore directories and/or objects found";
+                        logFileHashStore.fatal(errMsg);
+                        throw new IllegalStateException(errMsg);
+                    }
                 }
+            } else {
+                logFileHashStore.debug(
+                        "FileHashStore - 'hashstore.yaml' not found and store path not yet initialized.");
             }
-
         }
 
         // HashStore configuration has been checked, proceed with initialization

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -167,7 +167,7 @@ public class FileHashStore implements HashStore {
 
             if (Files.exists(storePath)) {
                 try (Stream<Path> walk = Files.walk(storePath)) {
-                    if (walk.anyMatch(path -> path != null && Files.exists(path))) {
+                    if (walk.anyMatch(Files::exists)) {
                         String errMsg = "FileHashStore - Missing 'hashstore.yaml' but HashStore directories and/or objects found";
                         logFileHashStore.fatal(errMsg);
                         throw new IllegalStateException(errMsg);

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -44,6 +44,7 @@ public class FileHashStore implements HashStore {
     private static final Log logFileHashStore = LogFactory.getLog(FileHashStore.class);
     private static final ArrayList<String> objectLockedIds = new ArrayList<>(100);
     private final Path STORE_ROOT;
+    private final Path HASHSTORE_YAML;
     private final int DIRECTORY_DEPTH;
     private final int DIRECTORY_WIDTH;
     private final String OBJECT_STORE_ALGORITHM;
@@ -141,11 +142,12 @@ public class FileHashStore implements HashStore {
                 + storeWidth + ". Store Algorithm: " + storeAlgorithm);
 
         // Write configuration file 'hashstore.yaml'
-        Path hashstoreYamlFilePath = Paths.get(this.STORE_ROOT + "/hashstore.yaml");
-        if (!Files.exists(hashstoreYamlFilePath)) {
+        this.HASHSTORE_YAML = this.STORE_ROOT.resolve("hashstore.yaml");
+        System.out.println(this.STORE_ROOT);
+        if (!Files.exists(this.HASHSTORE_YAML)) {
             String hashstoreYamlContent = FileHashStore.buildHashStoreYamlString(storePath, 3, 2, storeAlgorithm);
-            FileHashStore.putHashStoreYaml(hashstoreYamlContent, this.STORE_ROOT);
-            logFileHashStore.info("FileHashStore - 'hashstore.yaml' written to storePath: " + hashstoreYamlFilePath);
+            this.putHashStoreYaml(hashstoreYamlContent);
+            logFileHashStore.info("FileHashStore - 'hashstore.yaml' written to storePath: " + this.HASHSTORE_YAML);
         }
     }
 
@@ -157,8 +159,7 @@ public class FileHashStore implements HashStore {
      * @return HashMap of the properties
      */
     protected HashMap<String, Object> getHashStoreYaml() {
-        Path hashStoreYamlFilePath = Paths.get(this.STORE_ROOT + "/hashstore.yaml");
-        File hashStoreYaml = hashStoreYamlFilePath.toFile();
+        File hashStoreYaml = this.HASHSTORE_YAML.toFile();
         ObjectMapper om = new ObjectMapper(new YAMLFactory());
         HashMap<String, Object> hsProperties = new HashMap<>();
         try {
@@ -179,13 +180,11 @@ public class FileHashStore implements HashStore {
      * Write a 'hashstore.yaml' file to the given store (root) path
      * 
      * @param yamlString Content of the HashStore configuration
-     * @param storePath  Root directory of Store
      * @throws IOException If unable to write `hashtore.yaml`
      */
-    protected static void putHashStoreYaml(String yamlString, Path storePath) throws IOException {
-        Path hashstoreYamlFilePath = Paths.get(storePath + "/hashstore.yaml");
+    protected void putHashStoreYaml(String yamlString) throws IOException {
         try (BufferedWriter writer = new BufferedWriter(
-                new OutputStreamWriter(Files.newOutputStream(hashstoreYamlFilePath), StandardCharsets.UTF_8))) {
+                new OutputStreamWriter(Files.newOutputStream(this.HASHSTORE_YAML), StandardCharsets.UTF_8))) {
             writer.write(yamlString);
         } catch (IOException ioe) {
             logFileHashStore

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
-import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -140,25 +139,18 @@ public class FileHashStore implements HashStore {
 
         } else {
             // Check if HashStore exists at the given store path (and is missing config)
-            logFileHashStore.debug(
-                    "FileHashStore - 'hashstore.yaml' not found, check store path for objects and directories");
+            logFileHashStore
+                    .debug("FileHashStore - 'hashstore.yaml' not found, check store path for objects and directories.");
 
-            if (Files.exists(storePath)) {
-                boolean hashStoreExists = false;
-                try (Stream<Path> walk = Files.walk(storePath)) {
-                    if (walk.anyMatch(Files::exists)) {
-                        hashStoreExists = true;
-                    }
-                }
-                if (hashStoreExists) {
-                    String errMsg = "FileHashStore - Missing 'hashstore.yaml' but HashStore directories and/or objects found";
+            if (Files.isDirectory(storePath)) {
+                File[] storePathFileList = storePath.toFile().listFiles();
+                if (storePathFileList == null || storePathFileList.length > 0) {
+                    String errMsg = "FileHashStore - Missing 'hashstore.yaml' but HashStore directories and/or objects found.";
                     logFileHashStore.fatal(errMsg);
-                    throw new IllegalStateException();
+                    throw new IllegalStateException(errMsg);
                 }
             }
-            logFileHashStore.debug(
-                    "FileHashStore - 'hashstore.yaml' not found and store path not yet initialized.");
-
+            logFileHashStore.debug("FileHashStore - 'hashstore.yaml' not found and store path not yet initialized.");
         }
 
         // HashStore configuration has been checked, proceed with initialization

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -134,6 +134,14 @@ public class FileHashStore implements HashStore {
         this.OBJECT_STORE_ALGORITHM = storeAlgorithm;
         logFileHashStore.debug("FileHashStore - HashStore initialized. Store Depth: " + storeDepth + ". Store Width: "
                 + storeWidth + ". Store Algorithm: " + storeAlgorithm);
+
+        // Write configuration file 'hashstore.yaml'
+        Path hashstoreYamlFilePath = Paths.get(storePath + "/hashstore.yaml");
+        if (!Files.exists(hashstoreYamlFilePath)) {
+            String hashstoreYamlContent = FileHashStore.buildHashStoreYamlString(storePath, 3, 2, storeAlgorithm);
+            FileHashStore.writeHashStoreYaml(hashstoreYamlContent, storePath);
+            logFileHashStore.info("FileHashStore - 'hashstore.yaml' written to storePath: " + hashstoreYamlFilePath);
+        }
     }
 
     // Configuration Methods

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -101,6 +101,11 @@ public class FileHashStore implements HashStore {
         String storeAlgorithm = (String) hashstoreProperties.get(HashStoreProperties.storeAlgorithm.name());
 
         // Validate input parameters
+        if (storePath == null) {
+            String errMsg = "FileHashStore - storePath cannot be null.";
+            logFileHashStore.error(errMsg);
+            throw new NullPointerException(errMsg);
+        }
         if (storeDepth <= 0 || storeWidth <= 0) {
             String errMsg = "FileHashStore - Depth and width must be greater than 0. Depth: " + storeDepth + ". Width: "
                     + storeWidth;
@@ -151,17 +156,8 @@ public class FileHashStore implements HashStore {
         }
 
         // HashStore configuration has been reviewed, proceed with initialization
-        // If no path provided, create default path with user.dir root + /FileHashStore
-        if (storePath == null) {
-            String rootDirectory = System.getProperty("user.dir");
-            this.STORE_ROOT = Paths.get(rootDirectory).resolve("FileHashStore");
-            this.OBJECT_STORE_DIRECTORY = this.STORE_ROOT.resolve("objects");
-            logFileHashStore.debug("FileHashStore - storePath is null, directory created at: "
-                    + this.OBJECT_STORE_DIRECTORY);
-        } else {
-            this.STORE_ROOT = storePath;
-            this.OBJECT_STORE_DIRECTORY = storePath.resolve("objects");
-        }
+        this.STORE_ROOT = storePath;
+        this.OBJECT_STORE_DIRECTORY = storePath.resolve("objects");
         // Resolve tmp object directory path
         this.OBJECT_TMP_FILE_DIRECTORY = this.OBJECT_STORE_DIRECTORY.resolve("tmp");
         // Physically create store and tmp directory

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -114,15 +114,16 @@ public class FileHashStore implements HashStore {
         // Ensure algorithm supplied is not empty, not null and supported
         this.validateAlgorithm(storeAlgorithm);
 
-        // Check to see if configuration exists before instantiating
+        // Check to see if configuration exists before initializing
         Path hashstoreYamlPredictedPath = Paths.get(storePath + "/hashstore.yaml");
         if (Files.exists(hashstoreYamlPredictedPath)) {
-            // If 'hashstore.yaml' is found, verify given properties before init
+            logFileHashStore.debug("FileHashStore - 'hashstore.yaml' found, verifying properties.");
             HashMap<String, Object> hsProperties = this.getHashStoreYaml(storePath);
             Path existingStorePath = (Path) hsProperties.get("storePath");
             int existingStoreDepth = (int) hsProperties.get("storeDepth");
             int existingStoreWidth = (int) hsProperties.get("storeWidth");
             String existingStoreAlgorithm = (String) hsProperties.get("storeAlgorithm");
+            // Verify properties when 'hashstore.yaml' found
             if (!storePath.equals(existingStorePath)) {
                 String errMsg = "FileHashStore - Supplied store path: " + storePath
                         + " is not equal to the existing configuration: " + existingStorePath;
@@ -150,7 +151,8 @@ public class FileHashStore implements HashStore {
 
         } else {
             // Check if HashStore exists and throw exception if found
-            System.out.println("Else Statement Reached. Check to see if objects and/or directories exist");
+            logFileHashStore.debug(
+                    "FileHashStore - 'hashstore.yaml' not found, check to see if objects and/or directories exist");
         }
 
         // HashStore configuration has been checked, proceed with initialization
@@ -178,13 +180,14 @@ public class FileHashStore implements HashStore {
 
         // Write configuration file 'hashstore.yaml'
         Path hashstoreYaml = this.STORE_ROOT.resolve("hashstore.yaml");
-        System.out.println(this.STORE_ROOT);
         if (!Files.exists(hashstoreYaml)) {
-            String hashstoreYamlContent = FileHashStore.buildHashStoreYamlString(storePath, 3, 2, storeAlgorithm);
+            String hashstoreYamlContent = FileHashStore.buildHashStoreYamlString(this.STORE_ROOT, this.DIRECTORY_DEPTH,
+                    this.DIRECTORY_WIDTH, this.OBJECT_STORE_ALGORITHM);
             this.putHashStoreYaml(hashstoreYamlContent);
             logFileHashStore.info("FileHashStore - 'hashstore.yaml' written to storePath: " + hashstoreYaml);
         } else {
-            logFileHashStore.info("FileHashStore - 'hashstore.yaml' exists. Instantiating FileHashStore.");
+            logFileHashStore.info(
+                    "FileHashStore - 'hashstore.yaml' exists and has been verified. Initializing FileHashStore.");
         }
     }
 
@@ -260,7 +263,7 @@ public class FileHashStore implements HashStore {
                         "# Width of directories created when sharding an object to form the permanent address\n" +
                         "store_width: %d  # WARNING: DO NOT CHANGE UNLESS SETTING UP NEW HASHSTORE\n" +
                         "# Example:\n" +
-                        "# Below, objects are shown listed in directories that are 3 levels deep (DIR_DEPTH=3),\n" +
+                        "# Below, objects are shown listed in directories that are # levels deep (DIR_DEPTH=3),\n" +
                         "# with each directory consisting of 2 characters (DIR_WIDTH=2).\n" +
                         "#    /var/filehashstore/objects\n" +
                         "#    ├── 7f\n" +

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -110,6 +110,47 @@ public class FileHashStore implements HashStore {
         // Ensure algorithm supplied is not empty, not null and supported
         this.validateAlgorithm(storeAlgorithm);
 
+        // Check to see if configuration exists before instantiating
+        Path hashstoreYamlPredictedPath = Paths.get(storePath + "/hashstore.yaml");
+        if (Files.exists(hashstoreYamlPredictedPath)) {
+            // If 'hashstore.yaml' is found, verify given properties before init
+            HashMap<String, Object> hsProperties = this.getHashStoreYaml();
+            Path existingStorePath = (Path) hsProperties.get("store_path");
+            int existingStoreDepth = (int) hsProperties.get("store_depth");
+            int existingStoreWidth = (int) hsProperties.get("store_width");
+            String existingStoreAlgorithm = (String) hsProperties.get("store_algorithm");
+
+            if (!storePath.equals(existingStorePath)) {
+                String errMsg = "FileHashStore - Supplied store path: " + storePath
+                        + " is not equal to the existing configuration: " + existingStorePath;
+                logFileHashStore.fatal(errMsg);
+                throw new IllegalArgumentException(errMsg);
+            }
+            if (storeDepth != existingStoreDepth) {
+                String errMsg = "FileHashStore - Supplied store depth: " + storeDepth
+                        + " is not equal to the existing configuration: " + existingStoreDepth;
+                logFileHashStore.fatal(errMsg);
+                throw new IllegalArgumentException(errMsg);
+            }
+            if (storeWidth != existingStoreWidth) {
+                String errMsg = "FileHashStore - Supplied store width: " + storeWidth
+                        + " is not equal to the existing configuration: " + existingStoreWidth;
+                logFileHashStore.fatal(errMsg);
+                throw new IllegalArgumentException(errMsg);
+            }
+            if (!storeAlgorithm.equals(existingStoreAlgorithm)) {
+                String errMsg = "FileHashStore - Supplied store algorithm: " + storeAlgorithm
+                        + " is not equal to the existing configuration: " + existingStoreAlgorithm;
+                logFileHashStore.fatal(errMsg);
+                throw new IllegalArgumentException(errMsg);
+            }
+
+        } else {
+            // Check if HashStore exists and throw exception if found
+            System.out.println("Check to see if objects and/or directories exist");
+        }
+
+        // HashStore configuration has been reviewed, proceed with initialization
         // If no path provided, create default path with user.dir root + /FileHashStore
         if (storePath == null) {
             String rootDirectory = System.getProperty("user.dir");

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -247,6 +247,7 @@ public class FileHashStorePublicTest {
             new FileHashStore(storeProperties);
         } catch (Exception e) {
             e.printStackTrace();
+            System.out.println(e.getCause().getClass());
             assertEquals(e.getCause().getClass(), IllegalStateException.class);
             throw e;
         }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -246,6 +246,7 @@ public class FileHashStorePublicTest {
             // Instantiate second HashStore
             new FileHashStore(storeProperties);
         } catch (Exception e) {
+            e.printStackTrace();
             assertEquals(e.getCause().getClass(), IllegalStateException.class);
             throw e;
         }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -22,6 +23,7 @@ public class FileHashStorePublicTest {
     private static Path rootDirectory;
     private static Path objStringFull;
     private static Path objTmpStringFull;
+    private static FileHashStore fileHashStore;
 
     /**
      * Initialize FileHashStore
@@ -40,7 +42,7 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeAlgorithm", "SHA-256");
 
         try {
-            new FileHashStore(storeProperties);
+            fileHashStore = new FileHashStore(storeProperties);
         } catch (IOException e) {
             fail("IOException encountered: " + e.getMessage());
         } catch (NoSuchAlgorithmException nsae) {
@@ -123,26 +125,40 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeAlgorithm", "SHA-256");
         new FileHashStore(storeProperties);
 
-        String rootDirectory = System.getProperty("user.dir");
-        String objectPath = "FileHashStore";
+        // String rootDirectory = System.getProperty("user.dir");
+        Path userDirectory = Paths.get(System.getProperty("user.dir"));
+        Path rootDirectory = userDirectory.resolve("FileHashStore");
 
-        Path defaultObjDirectoryPath = Paths.get(rootDirectory).resolve(objectPath).resolve("objects");
+        Path defaultObjDirectoryPath = rootDirectory.resolve("objects");
         assertTrue(Files.exists(defaultObjDirectoryPath));
 
         Path defaultTmpDirectoryPath = defaultObjDirectoryPath.resolve("tmp");
         assertTrue(Files.exists(defaultTmpDirectoryPath));
 
-        // Delete the folders
+        // Delete the folders and config file
         Files.deleteIfExists(defaultTmpDirectoryPath);
         Files.deleteIfExists(defaultObjDirectoryPath);
+        Files.deleteIfExists(Paths.get(rootDirectory + "/hashstore.yaml"));
     }
 
     /**
      * Check that a hashstore configuration file is written and exists
      */
     @Test
-    public void testWriteHashstoreYaml() throws Exception {
-        Path hashstoreYamlFilePath = Paths.get(rootDirectory + "/hashstore.yaml");
-        assertTrue(Files.exists(hashstoreYamlFilePath));
+    public void testPutHashStoreYaml() {
+        Path hashStoreYamlFilePath = Paths.get(rootDirectory + "/hashstore.yaml");
+        assertTrue(Files.exists(hashStoreYamlFilePath));
+    }
+
+    /**
+     * Confirm retrieved 'hashstore.yaml' file content is accurate
+     */
+    @Test
+    public void testGetHashStoreYaml() {
+        HashMap<String, Object> hsProperties = fileHashStore.getHashStoreYaml();
+        assertEquals(hsProperties.get("storePath"), rootDirectory.toString());
+        assertEquals(hsProperties.get("storeDepth"), 3);
+        assertEquals(hsProperties.get("storeWidth"), 2);
+        assertEquals(hsProperties.get("storeAlgorithm"), "SHA-256");
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -242,14 +242,13 @@ public class FileHashStorePublicTest {
         // Delete configuration
         Files.delete(newStoreHashStoreYaml);
 
-        // try {
-        // Instantiate second HashStore
-        new FileHashStore(storeProperties);
-        // } catch (Exception e) {
-        // e.printStackTrace();
-        // System.out.println(e.getCause().getClass());
-        // assertEquals(e.getCause().getClass(), IllegalStateException.class);
-        // throw e;
-        // }
+        try {
+            // Instantiate second HashStore
+            new FileHashStore(storeProperties);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertEquals(e.getCause().getClass(), IllegalStateException.class);
+            throw e;
+        }
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -141,7 +141,7 @@ public class FileHashStorePublicTest {
     @Test
     public void testGetHashStoreYaml() {
         HashMap<String, Object> hsProperties = fileHashStore.getHashStoreYaml(rootDirectory);
-        assertEquals(hsProperties.get("storePath"), rootDirectory.toString());
+        assertEquals(hsProperties.get("storePath"), rootDirectory);
         assertEquals(hsProperties.get("storeDepth"), 3);
         assertEquals(hsProperties.get("storeWidth"), 2);
         assertEquals(hsProperties.get("storeAlgorithm"), "SHA-256");
@@ -161,19 +161,16 @@ public class FileHashStorePublicTest {
     }
 
     /**
-     * Test existing configuration file will raise exception when properties are
+     * Test existing configuration file will raise exception when algorithm is
      * different when instantiating FileHashStore
      */
     @Test(expected = IllegalArgumentException.class)
-    public void testExistingHashStoreConfiguration_diffStorePath() throws Exception {
-        Path hashYaml = rootDirectory.resolve("hashstore.yaml");
-        System.out.println(hashYaml);
+    public void testExistingHashStoreConfiguration_diffAlgorithm() throws Exception {
         HashMap<String, Object> storeProperties = new HashMap<>();
-        Path differentPath = Paths.get(System.getProperty("user.dir") + "/test");
-        storeProperties.put("storePath", differentPath);
+        storeProperties.put("storePath", rootDirectory);
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
-        storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeAlgorithm", "MD5");
         new FileHashStore(storeProperties);
     }
 
@@ -202,20 +199,6 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 1);
         storeProperties.put("storeAlgorithm", "SHA-256");
-        new FileHashStore(storeProperties);
-    }
-
-    /**
-     * Test existing configuration file will raise exception when properties are
-     * different when instantiating FileHashStore
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testExistingHashStoreConfiguration_diffAlgo() throws Exception {
-        HashMap<String, Object> storeProperties = new HashMap<>();
-        storeProperties.put("storePath", rootDirectory);
-        storeProperties.put("storeDepth", 3);
-        storeProperties.put("storeWidth", 2);
-        storeProperties.put("storeAlgorithm", "MD2");
         new FileHashStore(storeProperties);
     }
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -209,11 +209,6 @@ public class FileHashStorePublicTest {
     /**
      * Check that exception is raised when HashStore present but missing
      * configuration file 'hashstore.yaml'
-     *
-     * Note, we are checking for an IllegalArgumentException because the try block
-     * in the code when walking over files attempts to suppress the thrown
-     * 'IllegalStateException' (which won't retain the original exception).
-     * Expected exception is verified by asserting 'true' from when it is
      */
     @Test(expected = IllegalStateException.class)
     public void testExistingHashStoreConfiguration_missingYaml() throws Exception {

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -215,7 +215,7 @@ public class FileHashStorePublicTest {
      * 'IllegalStateException' (which won't retain the original exception).
      * Expected exception is verified by asserting 'true' from when it is
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void testExistingHashStoreConfiguration_missingYaml() throws Exception {
         // Create separate store
         HashMap<String, Object> storeProperties = new HashMap<>();

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -142,10 +142,6 @@ public class FileHashStorePublicTest {
      */
     @Test
     public void testWriteHashstoreYaml() throws Exception {
-        String storeAlgorithm = "SHA-256";
-        String hashstoreYaml = FileHashStore.buildHashStoreYamlString(rootDirectory, 3, 2, storeAlgorithm);
-        FileHashStore.writeHashStoreYaml(hashstoreYaml, rootDirectory);
-
         Path hashstoreYamlFilePath = Paths.get(rootDirectory + "/hashstore.yaml");
         assertTrue(Files.exists(hashstoreYamlFilePath));
     }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -242,14 +242,14 @@ public class FileHashStorePublicTest {
         // Delete configuration
         Files.delete(newStoreHashStoreYaml);
 
-        try {
-            // Instantiate second HashStore
-            new FileHashStore(storeProperties);
-        } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println(e.getCause().getClass());
-            assertEquals(e.getCause().getClass(), IllegalStateException.class);
-            throw e;
-        }
+        // try {
+        // Instantiate second HashStore
+        new FileHashStore(storeProperties);
+        // } catch (Exception e) {
+        // e.printStackTrace();
+        // System.out.println(e.getCause().getClass());
+        // assertEquals(e.getCause().getClass(), IllegalStateException.class);
+        // throw e;
+        // }
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -246,7 +246,7 @@ public class FileHashStorePublicTest {
             // Instantiate second HashStore
             new FileHashStore(storeProperties);
         } catch (Exception e) {
-            assertTrue(e.getCause().getClass().equals(IllegalStateException.class));
+            assertEquals(e.getCause().getClass(), IllegalStateException.class);
             throw e;
         }
     }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -66,7 +66,7 @@ public class FileHashStorePublicTest {
     @Test
     public void initObjDirectory() {
         Path checkStorePath = objStringFull;
-        assertTrue(Files.exists(checkStorePath));
+        assertTrue(Files.isDirectory(checkStorePath));
     }
 
     /**
@@ -75,7 +75,7 @@ public class FileHashStorePublicTest {
     @Test
     public void initObjTmpDirectory() {
         Path checkTmpPath = objTmpStringFull;
-        assertTrue(Files.exists(checkTmpPath));
+        assertTrue(Files.isDirectory(checkTmpPath));
     }
 
     /**

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -140,10 +140,83 @@ public class FileHashStorePublicTest {
      */
     @Test
     public void testGetHashStoreYaml() {
-        HashMap<String, Object> hsProperties = fileHashStore.getHashStoreYaml();
+        HashMap<String, Object> hsProperties = fileHashStore.getHashStoreYaml(rootDirectory);
         assertEquals(hsProperties.get("storePath"), rootDirectory.toString());
         assertEquals(hsProperties.get("storeDepth"), 3);
         assertEquals(hsProperties.get("storeWidth"), 2);
         assertEquals(hsProperties.get("storeAlgorithm"), "SHA-256");
     }
+
+    /**
+     * Test FileHashStore instantiates with matching config
+     */
+    @Test
+    public void testExistingHashStoreConfiguration_sameConfig() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", rootDirectory);
+        storeProperties.put("storeDepth", 3);
+        storeProperties.put("storeWidth", 2);
+        storeProperties.put("storeAlgorithm", "SHA-256");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test existing configuration file will raise exception when properties are
+     * different when instantiating FileHashStore
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testExistingHashStoreConfiguration_diffStorePath() throws Exception {
+        Path hashYaml = rootDirectory.resolve("hashstore.yaml");
+        System.out.println(hashYaml);
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        Path differentPath = Paths.get(System.getProperty("user.dir") + "/test");
+        storeProperties.put("storePath", differentPath);
+        storeProperties.put("storeDepth", 3);
+        storeProperties.put("storeWidth", 2);
+        storeProperties.put("storeAlgorithm", "SHA-256");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test existing configuration file will raise exception when depth is
+     * different when instantiating FileHashStore
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testExistingHashStoreConfiguration_diffDepth() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", rootDirectory);
+        storeProperties.put("storeDepth", 2);
+        storeProperties.put("storeWidth", 2);
+        storeProperties.put("storeAlgorithm", "SHA-256");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test existing configuration file will raise exception when width is
+     * different when instantiating FileHashStore
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testExistingHashStoreConfiguration_diffWidth() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", rootDirectory);
+        storeProperties.put("storeDepth", 3);
+        storeProperties.put("storeWidth", 1);
+        storeProperties.put("storeAlgorithm", "SHA-256");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test existing configuration file will raise exception when properties are
+     * different when instantiating FileHashStore
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testExistingHashStoreConfiguration_diffAlgo() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", rootDirectory);
+        storeProperties.put("storeDepth", 3);
+        storeProperties.put("storeWidth", 2);
+        storeProperties.put("storeAlgorithm", "MD2");
+        new FileHashStore(storeProperties);
+    }
+
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -114,9 +114,9 @@ public class FileHashStorePublicTest {
     }
 
     /**
-     * Confirm default file directories are created when storeDirectory is null
+     * Confirm that exception is thrown when storeDirectory is null
      */
-    @Test
+    @Test(expected = NullPointerException.class)
     public void initDefaultStore_directoryNull() throws Exception {
         HashMap<String, Object> storeProperties = new HashMap<>();
         storeProperties.put("storePath", null);
@@ -124,21 +124,6 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
         new FileHashStore(storeProperties);
-
-        // String rootDirectory = System.getProperty("user.dir");
-        Path userDirectory = Paths.get(System.getProperty("user.dir"));
-        Path rootDirectory = userDirectory.resolve("FileHashStore");
-
-        Path defaultObjDirectoryPath = rootDirectory.resolve("objects");
-        assertTrue(Files.exists(defaultObjDirectoryPath));
-
-        Path defaultTmpDirectoryPath = defaultObjDirectoryPath.resolve("tmp");
-        assertTrue(Files.exists(defaultTmpDirectoryPath));
-
-        // Delete the folders and config file
-        Files.deleteIfExists(defaultTmpDirectoryPath);
-        Files.deleteIfExists(defaultObjDirectoryPath);
-        Files.deleteIfExists(Paths.get(rootDirectory + "/hashstore.yaml"));
     }
 
     /**

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -19,6 +19,7 @@ import org.junit.rules.TemporaryFolder;
  * Test class for FileHashStore constructor
  */
 public class FileHashStorePublicTest {
+    private static Path rootDirectory;
     private static Path objStringFull;
     private static Path objTmpStringFull;
 
@@ -28,7 +29,7 @@ public class FileHashStorePublicTest {
     @BeforeClass
     public static void initializeFileHashStore() {
         Path root = tempFolder.getRoot().toPath();
-        Path rootDirectory = root.resolve("metacat");
+        rootDirectory = root.resolve("metacat");
         objStringFull = rootDirectory.resolve("objects");
         objTmpStringFull = rootDirectory.resolve("objects/tmp");
 
@@ -134,5 +135,18 @@ public class FileHashStorePublicTest {
         // Delete the folders
         Files.deleteIfExists(defaultTmpDirectoryPath);
         Files.deleteIfExists(defaultObjDirectoryPath);
+    }
+
+    /**
+     * Check that a hashstore configuration file is written and exists
+     */
+    @Test
+    public void testWriteHashstoreYaml() throws Exception {
+        String storeAlgorithm = "SHA-256";
+        String hashstoreYaml = FileHashStore.buildHashStoreYamlString(rootDirectory, 3, 2, storeAlgorithm);
+        FileHashStore.writeHashStoreYaml(hashstoreYaml, rootDirectory);
+
+        Path hashstoreYamlFilePath = Paths.get(rootDirectory + "/hashstore.yaml");
+        assertTrue(Files.exists(hashstoreYamlFilePath));
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -242,13 +242,7 @@ public class FileHashStorePublicTest {
         // Delete configuration
         Files.delete(newStoreHashStoreYaml);
 
-        try {
-            // Instantiate second HashStore
-            new FileHashStore(storeProperties);
-        } catch (Exception e) {
-            e.printStackTrace();
-            assertEquals(e.getCause().getClass(), IllegalStateException.class);
-            throw e;
-        }
+        // Instantiate second HashStore
+        new FileHashStore(storeProperties);
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -246,7 +246,6 @@ public class FileHashStorePublicTest {
             // Instantiate second HashStore
             new FileHashStore(storeProperties);
         } catch (Exception e) {
-            e.printStackTrace();
             assertEquals(e.getCause().getClass(), IllegalStateException.class);
             throw e;
         }


### PR DESCRIPTION
FileHashStore has been refactored to initialize via a configuration file `hashstore.yaml` in a given store path. It no longer allows a null store path (no default directories) and the calling app must explicitly declare where it intends the store to exist.
- Upon instantiation, it will check for the existence of `hashstore.yaml`.
    - If found, it compares the given properties to ensure that it matches the existing configuration.
    - If not found, it will check for the existence of HashStore at the given store path (objects and directories).
         - If there are objects, it will raise an exception that the configuration file is missing.

Once the properties have been verified, it will proceed to initialize with the given properties, ensuring consistent usage of the existing store.

**New Methods:**
- getHashStoreYaml()
- putHashStoreYaml()
- buildHashStoreYamlString()