### PR TITLE
Feature-11: storeMetadata Public API method

### DIFF
--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -1,6 +1,7 @@
 package org.dataone.hashstore;
 
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
@@ -62,15 +63,16 @@ public interface HashStore {
             throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException;
 
     /**
-     * The `storeMetadata` method is responsible for adding and/or updating metadata
-     * (ex. `sysmeta`) to disk using a given InputStream and a persistent identifier
-     * (pid). The metadata object consists of a header and body portion. The header
-     * is formed by writing the namespace/format (utf-8) of the metadata document
-     * followed by a null character `\x00` and the body follows immediately after.
+     * The `storeMetadata` method is responsible for adding/updating metadata
+     * (ex. `sysmeta`) to disk using a given InputStream, a persistent identifier
+     * (pid) and metadata format (formatId). The metadata object consists of a
+     * header and body portion. The header is formed by writing the namespace/format
+     * (utf-8) of the metadata document followed by a null character `\u0000` and
+     * the body (metadata content) follows immediately after.
      * 
-     * The header contains the metadata object's permanent address, which is
-     * determined by calculating the SHA-256 hex digest of the provided `pid` +
-     * `format_id`; and the body contains the metadata content (ex. `sysmeta`).
+     * The permanent address of the metadata document is determined by calculating
+     * the SHA-256 hex digest of the provided `pid` + `format_id`; and the body
+     * contains the metadata content (ex. `sysmeta`).
      * 
      * Upon successful storage of metadata, `store_metadata` returns a string that
      * represents the file's permanent address. Lastly, the metadata objects are
@@ -80,9 +82,18 @@ public interface HashStore {
      * @param pid      Authority-based identifier
      * @param formatId Metadata namespace/format
      * @return Metadata content identifier (string representing metadata address)
-     * @throws Exception TODO: Add specific exceptions
+     * @throws IOException              When there is an error writing the metadata
+     *                                  document
+     * @throws IllegalArgumentException Invalid values like null for metadata, or
+     *                                  empty pids and formatIds
+     * @throws FileNotFoundException    When temp metadata file is not found
+     * @throws InterruptedException     metadataLockedIds synchronization issue
+     * @throws NoSuchAlgorithmException Algorithm used to calculate permanent
+     *                                  address is not supported
      */
-    String storeMetadata(InputStream metadata, String pid, String formatId) throws Exception;
+    String storeMetadata(InputStream metadata, String pid, String formatId)
+            throws IOException, IllegalArgumentException, FileNotFoundException, InterruptedException,
+            NoSuchAlgorithmException;
 
     /**
      * The `retrieveObject` method retrieves an object from disk using a given

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -62,24 +62,27 @@ public interface HashStore {
             throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException;
 
     /**
-     * The `storeSysmeta` method is responsible for adding and/or updating metadata
-     * (`sysmeta`) to disk using a given InputStream and a persistent identifier
+     * The `storeMetadata` method is responsible for adding and/or updating metadata
+     * (ex. `sysmeta`) to disk using a given InputStream and a persistent identifier
      * (pid). The metadata object consists of a header and body portion. The header
      * is formed by writing the namespace/format (utf-8) of the metadata document
      * followed by a null character `\x00` and the body follows immediately after.
      * 
-     * Upon successful storage of sysmeta, the method returns a String that
-     * represents the file's permanent address, and similarly to storeObject, this
-     * permanent address is determined by calculating the SHA-256 hex digest of the
-     * provided pid. Finally, sysmeta are stored in parallel to objects in the
-     * `/[...storeDirectory]/sysmeta/` directory.
+     * The header contains the metadata object's permanent address, which is
+     * determined by calculating the SHA-256 hex digest of the provided `pid` +
+     * `format_id`; and the body contains the metadata content (ex. `sysmeta`).
      * 
-     * @param sysmeta Input stream to metadata document
-     * @param pid     Authority-based identifier
-     * @return String representing metadata address
+     * Upon successful storage of metadata, `store_metadata` returns a string that
+     * represents the file's permanent address. Lastly, the metadata objects are
+     * stored in parallel to objects in the `/store_directory/metadata/` directory.
+     * 
+     * @param metadata Input stream to metadata document
+     * @param pid      Authority-based identifier
+     * @param formatId Metadata namespace/format
+     * @return Metadata content identifier (string representing metadata address)
      * @throws Exception TODO: Add specific exceptions
      */
-    String storeSysmeta(InputStream sysmeta, String pid) throws Exception;
+    String storeMetadata(InputStream metadata, String pid, String formatId) throws Exception;
 
     /**
      * The `retrieveObject` method retrieves an object from disk using a given
@@ -94,14 +97,15 @@ public interface HashStore {
     BufferedReader retrieveObject(String pid) throws Exception;
 
     /**
-     * The 'retrieveSysmeta' method retrieves the metadata content from disk and
-     * returns it in the form of a String using a given persistent identifier.
+     * The 'retrieveMetadata' method retrieves the metadata content of a given pid
+     * and metadata namespace from disk and returns it in the form of a String.
      * 
-     * @param pid Authority-based identifier
+     * @param pid      Authority-based identifier
+     * @param formatId Metadata namespace/format
      * @return Sysmeta (metadata) document of given pid
      * @throws Exception TODO: Add specific exceptions
      */
-    String retrieveSysmeta(String pid) throws Exception;
+    String retrieveMetadata(String pid, String formatId) throws Exception;
 
     /**
      * The 'deleteObject' method deletes an object permanently from disk using a
@@ -114,14 +118,16 @@ public interface HashStore {
     boolean deleteObject(String pid) throws Exception;
 
     /**
-     * The 'deleteSysmeta' method deletes an metadata document (sysmeta) permanently
-     * from disk using a given persistent identifier.
+     * The 'deleteMetadata' method deletes a metadata document (ex. `sysmeta`)
+     * permanently from disk using a given persistent identifier and its respective
+     * metadata namespace.
      * 
-     * @param pid Authority-based identifier
+     * @param pid      Authority-based identifier
+     * @param formatId Metadata namespace/format
      * @return
      * @throws Exception TODO: Add specific exceptions
      */
-    boolean deleteSysmeta(String pid) throws Exception;
+    boolean deleteMetadata(String pid, String formatId) throws Exception;
 
     /**
      * The 'getHexDigest' method calculates the hex digest of an object that exists

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -682,7 +682,7 @@ public class FileHashStore implements HashStore {
                             + ". Deleted tmpFile: " + tmpFile.getName());
         } else {
             File permFile = objHashAddressPath.toFile();
-            boolean hasMoved = this.move(tmpFile, permFile);
+            boolean hasMoved = this.move(tmpFile, permFile, "object");
             if (hasMoved) {
                 isDuplicate = false;
             }
@@ -995,10 +995,14 @@ public class FileHashStore implements HashStore {
     }
 
     /**
-     * Moves an object from one location to another if the object does not exist
+     * Moves an object from one location to another. When the "entity" given is
+     * "object", if the target already exists, it will throw an exception to prevent
+     * the target object to be overwritten. Data "object" files are stored once and
+     * only once.
      * 
-     * @param source file to move
-     * @param target where to move the file
+     * @param source File to move
+     * @param target Where to move the file
+     * @param entity Type of object to move
      * 
      * @return true if file has been moved
      * 
@@ -1009,9 +1013,9 @@ public class FileHashStore implements HashStore {
      *                                         (usually encountered when moving
      *                                         across file systems)
      */
-    protected boolean move(File source, File target)
+    protected boolean move(File source, File target, String entity)
             throws IOException, SecurityException, AtomicMoveNotSupportedException, FileAlreadyExistsException {
-        if (target.exists()) {
+        if (entity == "object" && target.exists()) {
             String errMsg = "FileHashStore.move - File already exists for target: " + target;
             logFileHashStore.debug(errMsg);
             throw new FileAlreadyExistsException(errMsg);
@@ -1105,7 +1109,7 @@ public class FileHashStore implements HashStore {
         boolean tmpMetadataWritten = this.writeToTmpMetadataFile(tmpMetadataFile, metadata, checkedFormatId);
         if (tmpMetadataWritten) {
             File permMeadataFile = metadataCidAbsPath.toFile();
-            this.move(tmpMetadataFile, permMeadataFile);
+            this.move(tmpMetadataFile, permMeadataFile, null);
         }
         logFileHashStore
                 .info("FileHashStore.putObject - Move metadata success, permanent address: " + metadataCidAbsPath);

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -552,11 +552,11 @@ public class FileHashStore implements HashStore {
      * checksumAlgorithm is provided, FileHashStore will validate the given
      * checksum against the hex digest produced of the supplied checksumAlgorithm.
      * 
-     * @param object              inputstream for file
-     * @param pid                 authority based identifier
-     * @param additionalAlgorithm optional checksum value to generate in hex digests
-     * @param checksum            value of checksum to validate against
-     * @param checksumAlgorithm   algorithm of checksum submitted
+     * @param object              Inputstream for file
+     * @param pid                 Authority-based identifier
+     * @param additionalAlgorithm Optional checksum value to generate in hex digests
+     * @param checksum            Value of checksum to validate against
+     * @param checksumAlgorithm   Algorithm of checksum submitted
      * 
      * @return A HashAddress object that contains the file id, relative path,
      *         absolute path, duplicate status and a checksum map based on the
@@ -699,11 +699,11 @@ public class FileHashStore implements HashStore {
      * Checks whether a given algorithm is supported based on class variable
      * supportedHashAlgorithms
      * 
-     * @param algorithm string value (ex. SHA-256)
+     * @param algorithm String value (ex. SHA-256)
      * @return True if an algorithm is supported
-     * @throws NullPointerException     algorithm cannot be null
-     * @throws IllegalArgumentException algorithm cannot be empty
-     * @throws NoSuchAlgorithmException algorithm not supported
+     * @throws NullPointerException     Algorithm cannot be null
+     * @throws IllegalArgumentException Algorithm cannot be empty
+     * @throws NoSuchAlgorithmException Algorithm not supported
      */
     protected boolean validateAlgorithm(String algorithm)
             throws NullPointerException, IllegalArgumentException, NoSuchAlgorithmException {
@@ -1047,6 +1047,20 @@ public class FileHashStore implements HashStore {
         }
     }
 
+    /**
+     * Takes a given input stream and writes it to its permanent address on disk
+     * based on the SHA-256 hex digest of the given pid + formatId. If no formatId
+     * is supplied, it will use the default store namespace as defined by
+     * `hashstore.yaml`
+     * 
+     * @param metadata Inputstream to metadata
+     * @param pid      Authority-based identifier
+     * @param formatId Metadata formatId or namespace
+     * @return
+     * @throws NoSuchAlgorithmException When the algorithm used to calculate
+     *                                  permanent address is not supported
+     * @throws IOException              I/O error when writing to tmp file
+     */
     protected String putMetadata(InputStream metadata, String pid, String formatId)
             throws NoSuchAlgorithmException, IOException {
         logFileHashStore.debug(
@@ -1094,7 +1108,7 @@ public class FileHashStore implements HashStore {
             this.move(tmpMetadataFile, permMeadataFile);
         }
         logFileHashStore
-                .debug("FileHashStore.putObject - Move metadata success, permanent address: " + metadataCidAbsPath);
+                .info("FileHashStore.putObject - Move metadata success, permanent address: " + metadataCidAbsPath);
         return metadataCid;
     }
 

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1015,7 +1015,7 @@ public class FileHashStore implements HashStore {
      */
     protected boolean move(File source, File target, String entity)
             throws IOException, SecurityException, AtomicMoveNotSupportedException, FileAlreadyExistsException {
-        if (entity == "object" && target.exists()) {
+        if (entity.equals("object") && target.exists()) {
             String errMsg = "FileHashStore.move - File already exists for target: " + target;
             logFileHashStore.debug(errMsg);
             throw new FileAlreadyExistsException(errMsg);
@@ -1109,7 +1109,7 @@ public class FileHashStore implements HashStore {
         boolean tmpMetadataWritten = this.writeToTmpMetadataFile(tmpMetadataFile, metadata, checkedFormatId);
         if (tmpMetadataWritten) {
             File permMeadataFile = metadataCidAbsPath.toFile();
-            this.move(tmpMetadataFile, permMeadataFile, null);
+            this.move(tmpMetadataFile, permMeadataFile, "metadata");
         }
         logFileHashStore
                 .info("FileHashStore.putObject - Move metadata success, permanent address: " + metadataCidAbsPath);
@@ -1134,7 +1134,7 @@ public class FileHashStore implements HashStore {
 
         try {
             // Write formatId and null character (header)
-            byte[] metadataHeaderBytes = formatId.getBytes("UTF-8");
+            byte[] metadataHeaderBytes = formatId.getBytes(StandardCharsets.UTF_8);
             os.write(metadataHeaderBytes);
             // Write null character
             os.write('\u0000');

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1113,7 +1113,8 @@ public class FileHashStore implements HashStore {
     }
 
     /**
-     * Write the contents of the given metadataStream into a file
+     * Write the given formatId, followed by a null character `\u0000`, and metadata
+     * content into a file
      * 
      * @param tmpFile        File to write into
      * @param metadataStream Stream of metadata content
@@ -1132,7 +1133,7 @@ public class FileHashStore implements HashStore {
             byte[] metadataHeaderBytes = formatId.getBytes("UTF-8");
             os.write(metadataHeaderBytes);
             // Write null character
-            os.write('\0');
+            os.write('\u0000');
 
             // Write metadata content (body)
             byte[] buffer = new byte[8192];

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -682,8 +682,7 @@ public class FileHashStore implements HashStore {
                             + ". Deleted tmpFile: " + tmpFile.getName());
         } else {
             File permFile = objHashAddressPath.toFile();
-            // boolean hasMoved = this.move(tmpFile, permFile, "object");
-            boolean hasMoved = this.moveObject(tmpFile, permFile);
+            boolean hasMoved = this.move(tmpFile, permFile, "object");
             if (hasMoved) {
                 isDuplicate = false;
             }
@@ -1017,63 +1016,6 @@ public class FileHashStore implements HashStore {
     protected boolean move(File source, File target, String entity)
             throws IOException, SecurityException, AtomicMoveNotSupportedException, FileAlreadyExistsException {
         if (entity.equals("object") && target.exists()) {
-            String errMsg = "FileHashStore.move - File already exists for target: " + target;
-            logFileHashStore.debug(errMsg);
-            throw new FileAlreadyExistsException(errMsg);
-        }
-
-        File destinationDirectory = new File(target.getParent());
-        // Create parent directory if it doesn't exist
-        if (!destinationDirectory.exists()) {
-            Path destinationDirectoryPath = destinationDirectory.toPath();
-            Files.createDirectories(destinationDirectoryPath);
-        }
-
-        // Move file
-        Path sourceFilePath = source.toPath();
-        Path targetFilePath = target.toPath();
-        try {
-            Files.move(sourceFilePath, targetFilePath, StandardCopyOption.ATOMIC_MOVE);
-            logFileHashStore.debug("FileHashStore.move - file moved from: " + sourceFilePath + ", to: "
-                    + targetFilePath);
-            return true;
-
-        } catch (AtomicMoveNotSupportedException amnse) {
-            logFileHashStore.error(
-                    "FileHashStore.move - StandardCopyOption.ATOMIC_MOVE failed. AtomicMove is not supported across file systems. Source: "
-                            + source + ". Target: " + target);
-            throw amnse;
-
-        } catch (IOException ioe) {
-            logFileHashStore.error("FileHashStore.move - Unable to move file. Source: " + source
-                    + ". Target: " + target);
-            throw ioe;
-
-        }
-    }
-
-    /**
-     * Moves an object from one location to another. When the "entity" given is
-     * "object", if the target already exists, it will throw an exception to prevent
-     * the target object to be overwritten. Data "object" files are stored once and
-     * only once.
-     * 
-     * @param source File to move
-     * @param target Where to move the file
-     * @param entity Type of object to move
-     * 
-     * @return true if file has been moved
-     * 
-     * @throws FileAlreadyExistsException      Target file already exists
-     * @throws IOException                     Unable to create parent directory
-     * @throws SecurityException               Insufficient permissions to move file
-     * @throws AtomicMoveNotSupportedException When ATOMIC_MOVE is not supported
-     *                                         (usually encountered when moving
-     *                                         across file systems)
-     */
-    protected boolean moveObject(File source, File target)
-            throws IOException, SecurityException, AtomicMoveNotSupportedException, FileAlreadyExistsException {
-        if (target.exists()) {
             String errMsg = "FileHashStore.move - File already exists for target: " + target;
             logFileHashStore.debug(errMsg);
             throw new FileAlreadyExistsException(errMsg);

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1047,7 +1047,7 @@ public class FileHashStore implements HashStore {
         }
     }
 
-    public String putMetadata(InputStream metadata, String pid, String formatId)
+    protected String putMetadata(InputStream metadata, String pid, String formatId)
             throws NoSuchAlgorithmException, IOException {
         logFileHashStore.debug(
                 "FileHashStore.putMetadata - Called to put metadata for pid:" + pid + " , with metadata namespace: "
@@ -1072,8 +1072,8 @@ public class FileHashStore implements HashStore {
         if (formatId == null) {
             checkedFormatId = this.METADATA_NAMESPACE;
         } else if (formatId.trim().isEmpty()) {
-            String errMsg = "FileHashStore.putMetadata - formatId (metadata namespace) cannot be empty, it must be"
-                    + " supplied or null for default store namespace.";
+            String errMsg = "FileHashStore.putMetadata - formatId (metadata namespace) cannot be empty, it must"
+                    + " be supplied, or null for the default store namespace.";
             logFileHashStore.error(errMsg);
             throw new IllegalArgumentException(errMsg);
         } else {
@@ -1098,7 +1098,16 @@ public class FileHashStore implements HashStore {
         return metadataCid;
     }
 
-    public boolean writeToTmpMetadataFile(File tmpFile, InputStream metadataStream)
+    /**
+     * Write the contents of the given metadataStream into a file
+     * 
+     * @param tmpFile        File to write into
+     * @param metadataStream Stream of metadata content
+     * @return
+     * @throws IOException           When an I/O error occurs
+     * @throws FileNotFoundException When given file to write into is not found
+     */
+    protected boolean writeToTmpMetadataFile(File tmpFile, InputStream metadataStream)
             throws IOException, FileNotFoundException {
         FileOutputStream os = new FileOutputStream(tmpFile);
 

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -436,7 +436,7 @@ public class FileHashStore implements HashStore {
     }
 
     @Override
-    public String storeSysmeta(InputStream sysmeta, String pid) throws Exception {
+    public String storeMetadata(InputStream sysmeta, String pid, String formatId) throws Exception {
         // TODO: Implement method
         return null;
     }
@@ -448,7 +448,7 @@ public class FileHashStore implements HashStore {
     }
 
     @Override
-    public String retrieveSysmeta(String pid) throws Exception {
+    public String retrieveMetadata(String pid, String formatId) throws Exception {
         // TODO: Implement method
         return null;
     }
@@ -460,7 +460,7 @@ public class FileHashStore implements HashStore {
     }
 
     @Override
-    public boolean deleteSysmeta(String pid) throws Exception {
+    public boolean deleteMetadata(String pid, String formatId) throws Exception {
         // TODO: Implement method
         return false;
     }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -865,7 +865,7 @@ public class FileHashStore implements HashStore {
                             + additionalAlgorithm);
             additionalAlgo = MessageDigest.getInstance(additionalAlgorithm);
         }
-        if (checksumAlgorithm != null && checksumAlgorithm != additionalAlgorithm) {
+        if (checksumAlgorithm != null && !checksumAlgorithm.equals(additionalAlgorithm)) {
             logFileHashStore.debug(
                     "FileHashStore.writeToTmpFileAndGenerateChecksums - Adding checksum algorithm to hex digest map, algorithm: "
                             + checksumAlgorithm);
@@ -885,7 +885,7 @@ public class FileHashStore implements HashStore {
                 if (additionalAlgorithm != null) {
                     additionalAlgo.update(buffer, 0, bytesRead);
                 }
-                if (checksumAlgorithm != null && checksumAlgorithm != additionalAlgorithm) {
+                if (checksumAlgorithm != null && !checksumAlgorithm.equals(additionalAlgorithm)) {
                     checksumAlgo.update(buffer, 0, bytesRead);
                 }
             }
@@ -913,7 +913,7 @@ public class FileHashStore implements HashStore {
             String extraAlgoDigest = DatatypeConverter.printHexBinary(additionalAlgo.digest()).toLowerCase();
             hexDigests.put(additionalAlgorithm, extraAlgoDigest);
         }
-        if (checksumAlgorithm != null && checksumAlgorithm != additionalAlgorithm) {
+        if (checksumAlgorithm != null && !checksumAlgorithm.equals(additionalAlgorithm)) {
             String extraChecksumDigest = DatatypeConverter.printHexBinary(checksumAlgo.digest()).toLowerCase();
             hexDigests.put(checksumAlgorithm, extraChecksumDigest);
         }

--- a/src/test/java/org/dataone/hashstore/HashStoreTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreTest.java
@@ -36,6 +36,7 @@ public class HashStoreTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
 
         try {
             hashStore = HashStoreFactory.getHashStore(classPackage, storeProperties);
@@ -70,6 +71,7 @@ public class HashStoreTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
         hashStore = HashStoreFactory.getHashStore(null, storeProperties);
     }
 
@@ -83,7 +85,7 @@ public class HashStoreTest {
     }
 
     /**
-     * Test mystore stores file successfully
+     * Test hashStore instance stores file successfully
      */
     @Test
     public void hashStore_storeObjects() throws Exception {

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -322,12 +322,18 @@ public class FileHashStoreInterfaceTest {
      * The thread that does not encounter an exception will store the given
      * object, and verifies that the object is stored successfully.
      * 
-     * The test expects exceptions to be encountered, which can be either a
-     * `RunTimeException` or a `FileAlreadyExistsException`. This is because the
-     * rapid execution of threads can result in bypassing the object lock and
-     * the failure to throw a RunTimeException. However, since the file should
-     * already have been written to disk, a`FileAlreadyExistsException` will be
-     * thrown, ensuring that an object is never stored twice.
+     * The test expects exceptions to be encountered, will be either be a
+     * `RunTimeException` or an `pidObjectExistsException`. This is because the
+     * rapid execution of threads can result in bypassing the object lock (the
+     * object is stored and released so quickly that object synchronization is
+     * redundant).
+     * 
+     * If a call is made to 'storeObject' for a pid that is already being stored, a
+     * `RunTimeException` will be thrown. If the pid is released after the object is
+     * stored before other threads are submitted, it will run into a
+     * `pidObjectExistsException` as `putObject` will check for the existence of a
+     * given data object before it attempts to generate a temp file (write to it,
+     * generate checksums, etc.)
      */
     @Test
     public void storeObject_objectLockedIds() throws Exception {

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -316,7 +316,7 @@ public class FileHashStoreInterfaceTest {
 
     /**
      * Tests that the `storeObject` method can store an object successfully with
-     * multiple threads (5). This test uses three futures (threads) that run
+     * multiple threads (5). This test uses five futures (threads) that run
      * concurrently, all except one of which will encounter an `ExecutionException`.
      * The thread that does not encounter an exception will store the given
      * object, and verifies that the object is stored successfully.

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -456,8 +456,9 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                System.out.println(e.getClass());
                 e.printStackTrace();
-                assertTrue(e instanceof RuntimeException);
+                assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
         });
         Future<?> future2 = executorService.submit(() -> {
@@ -470,8 +471,9 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                System.out.println(e.getClass());
                 e.printStackTrace();
-                assertTrue(e instanceof RuntimeException);
+                assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
         });
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -349,6 +349,7 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                e.printStackTrace();
                 assertTrue(e instanceof RuntimeException || e instanceof FileAlreadyExistsException);
             }
         });
@@ -362,6 +363,7 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                e.printStackTrace();
                 assertTrue(e instanceof RuntimeException || e instanceof FileAlreadyExistsException);
             }
         });
@@ -375,6 +377,7 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                e.printStackTrace();
                 assertTrue(e instanceof RuntimeException || e instanceof FileAlreadyExistsException);
             }
         });

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -323,13 +323,13 @@ public class FileHashStoreInterfaceTest {
      * object, and verifies that the object is stored successfully.
      * 
      * The threads that run into exceptions will encounter a `RunTimeException` or
-     * a `pidObjectExistsException`. If a call is made to 'storeObject' for a pid
+     * a `PidObjectExistsException`. If a call is made to 'storeObject' for a pid
      * that is already in progress of being stored, a `RunTimeException` will be
      * thrown.
      * 
      * If the pid is released after the object is stored before other threads are
      * submitted (`storeObject` is rapidly executed), it will run into a
-     * `pidObjectExistsException` as `putObject` checks for the existence of a given
+     * `PidObjectExistsException` as `putObject` checks for the existence of a given
      * data object before it attempts to generate a temp file (write to it, generate
      * checksums, etc.).
      */

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -220,25 +220,6 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Verify that storeObject throws an exception when expected to validate object
-     * but checksum is not available/part of the hex digest map
-     */
-    @Test(expected = NoSuchAlgorithmException.class)
-    public void storeObject_missingChecksumValue() throws Exception {
-        // Get test file to "upload"
-        String pid = "jtao.1700.1";
-        Path testDataFile = testData.getTestFile(pid);
-
-        String checksumCorrect = "9c25df1c8ba1d2e57bb3fd4785878b85";
-
-        InputStream dataStream = Files.newInputStream(testDataFile);
-        HashAddress address = fileHashStore.storeObject(dataStream, pid, null, checksumCorrect, "MD2");
-
-        File objAbsPath = new File(address.getAbsPath());
-        assertTrue(objAbsPath.exists());
-    }
-
-    /**
      * Verify that storeObject generates an additional checksum
      */
     @Test

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -46,6 +46,7 @@ public class FileHashStoreInterfaceTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
 
         try {
             this.fileHashStore = new FileHashStore(storeProperties);

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -350,7 +350,7 @@ public class FileHashStoreInterfaceTest {
                 }
             } catch (Exception e) {
                 e.printStackTrace();
-                assertTrue(e instanceof RuntimeException || e instanceof FileAlreadyExistsException);
+                assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
         });
         Future<?> future2 = executorService.submit(() -> {
@@ -364,7 +364,7 @@ public class FileHashStoreInterfaceTest {
                 }
             } catch (Exception e) {
                 e.printStackTrace();
-                assertTrue(e instanceof RuntimeException || e instanceof FileAlreadyExistsException);
+                assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
         });
         Future<?> future3 = executorService.submit(() -> {
@@ -378,7 +378,7 @@ public class FileHashStoreInterfaceTest {
                 }
             } catch (Exception e) {
                 e.printStackTrace();
-                assertTrue(e instanceof RuntimeException || e instanceof FileAlreadyExistsException);
+                assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
         });
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -322,18 +322,16 @@ public class FileHashStoreInterfaceTest {
      * The thread that does not encounter an exception will store the given
      * object, and verifies that the object is stored successfully.
      * 
-     * The test expects exceptions to be encountered, will be either be a
-     * `RunTimeException` or an `pidObjectExistsException`. This is because the
-     * rapid execution of threads can result in bypassing the object lock (the
-     * object is stored and released so quickly that object synchronization is
-     * redundant).
+     * The threads that run into exceptions will encounter a `RunTimeException` or
+     * a `pidObjectExistsException`. If a call is made to 'storeObject' for a pid
+     * that is already in progress of being stored, a `RunTimeException` will be
+     * thrown.
      * 
-     * If a call is made to 'storeObject' for a pid that is already being stored, a
-     * `RunTimeException` will be thrown. If the pid is released after the object is
-     * stored before other threads are submitted, it will run into a
-     * `pidObjectExistsException` as `putObject` will check for the existence of a
-     * given data object before it attempts to generate a temp file (write to it,
-     * generate checksums, etc.)
+     * If the pid is released after the object is stored before other threads are
+     * submitted (`storeObject` is rapidly executed), it will run into a
+     * `pidObjectExistsException` as `putObject` checks for the existence of a given
+     * data object before it attempts to generate a temp file (write to it, generate
+     * checksums, etc.).
      */
     @Test
     public void storeObject_objectLockedIds() throws Exception {

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -352,6 +352,7 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                System.out.println(e.getClass());
                 e.printStackTrace();
                 assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
@@ -366,6 +367,7 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                System.out.println(e.getClass());
                 e.printStackTrace();
                 assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
@@ -380,6 +382,7 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                System.out.println(e.getClass());
                 e.printStackTrace();
                 assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
@@ -394,6 +397,7 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                System.out.println(e.getClass());
                 e.printStackTrace();
                 assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }
@@ -408,6 +412,7 @@ public class FileHashStoreInterfaceTest {
                     assertTrue(permAddress.exists());
                 }
             } catch (Exception e) {
+                System.out.println(e.getClass());
                 e.printStackTrace();
                 assertTrue(e instanceof RuntimeException || e instanceof PidObjectExistsException);
             }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -477,11 +477,13 @@ public class FileHashStoreProtectedTest {
                     addAlgo);
 
             // Validate checksum values
+            String md2 = testData.pidData.get(pid).get("md2");
             String md5 = testData.pidData.get(pid).get("md5");
             String sha1 = testData.pidData.get(pid).get("sha1");
             String sha256 = testData.pidData.get(pid).get("sha256");
             String sha384 = testData.pidData.get(pid).get("sha384");
             String sha512 = testData.pidData.get(pid).get("sha512");
+            assertEquals(md2, hexDigests.get("MD2"));
             assertEquals(md5, hexDigests.get("MD5"));
             assertEquals(sha1, hexDigests.get("SHA-1"));
             assertEquals(sha256, hexDigests.get("SHA-256"));

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -732,12 +732,13 @@ public class FileHashStoreProtectedTest {
         for (String pid : testData.pidList) {
             File newTmpFile = generateTemporaryFile();
             String pidFormatted = pid.replace("/", "_");
+            String formatId = (String) this.fhsProperties.get("storeMetadataNamespace");
 
             // Get test metadata file
             Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
-            boolean metadataWritten = this.fileHashStore.writeToTmpMetadataFile(newTmpFile, metadataStream);
+            boolean metadataWritten = this.fileHashStore.writeToTmpMetadataFile(newTmpFile, metadataStream, formatId);
             assertTrue(metadataWritten);
         }
     }
@@ -753,12 +754,13 @@ public class FileHashStoreProtectedTest {
         for (String pid : testData.pidList) {
             File newTmpFile = generateTemporaryFile();
             String pidFormatted = pid.replace("/", "_");
+            String formatId = (String) this.fhsProperties.get("storeMetadataNamespace");
 
             // Get test metadata file
             Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
-            boolean metadataWritten = this.fileHashStore.writeToTmpMetadataFile(newTmpFile, metadataStream);
+            boolean metadataWritten = this.fileHashStore.writeToTmpMetadataFile(newTmpFile, metadataStream, formatId);
             assertTrue(metadataWritten);
 
             long tmpMetadataFileSize = Files.size(newTmpFile.toPath());

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -640,7 +640,7 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
-     * Test putMetadata stores metadata as expceted
+     * Test putMetadata stores metadata as expected
      */
     @Test
     public void putMetadata() throws Exception {
@@ -744,6 +744,9 @@ public class FileHashStoreProtectedTest {
 
     /**
      * Check that tmp metadata is actually written by verifying file size
+     * 
+     * Reminder: We cannot do a size comparison directly because the metadata file
+     * stored contains the given namespace/formatId as well
      */
     @Test
     public void writeToTmpMetadataFile_tmpFileSize() throws Exception {
@@ -758,9 +761,8 @@ public class FileHashStoreProtectedTest {
             boolean metadataWritten = this.fileHashStore.writeToTmpMetadataFile(newTmpFile, metadataStream);
             assertTrue(metadataWritten);
 
-            long testMetadataFileSize = Files.size(testMetaDataFile);
             long tmpMetadataFileSize = Files.size(newTmpFile.toPath());
-            assertEquals(testMetadataFileSize, tmpMetadataFileSize);
+            assertTrue(tmpMetadataFileSize > 0);
         }
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -624,7 +624,7 @@ public class FileHashStoreProtectedTest {
         String targetString = tempFolder.getRoot().toString() + "/testmove/test_tmp_object.tmp";
         File targetFile = new File(targetString);
 
-        this.fileHashStore.move(newTmpFile, targetFile);
+        this.fileHashStore.move(newTmpFile, targetFile, "object");
         assertTrue(targetFile.exists());
     }
 
@@ -636,10 +636,10 @@ public class FileHashStoreProtectedTest {
         File newTmpFile = generateTemporaryFile();
         String targetString = tempFolder.getRoot().toString() + "/testmove/test_tmp_object.tmp";
         File targetFile = new File(targetString);
-        this.fileHashStore.move(newTmpFile, targetFile);
+        this.fileHashStore.move(newTmpFile, targetFile, "object");
 
         File newTmpFileTwo = generateTemporaryFile();
-        this.fileHashStore.move(newTmpFileTwo, targetFile);
+        this.fileHashStore.move(newTmpFileTwo, targetFile, "object");
     }
 
     /**

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -42,6 +42,7 @@ public class FileHashStoreProtectedTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
 
         try {
             this.fileHashStore = new FileHashStore(storeProperties);

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -643,6 +643,39 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
+     * Confirm that NullPointerException is thrown when entity is null
+     */
+    @Test(expected = NullPointerException.class)
+    public void testMove_entityNull() throws Exception {
+        File newTmpFile = generateTemporaryFile();
+        String targetString = tempFolder.getRoot().toString() + "/testmove/test_tmp_object.tmp";
+        File targetFile = new File(targetString);
+        this.fileHashStore.move(newTmpFile, targetFile, null);
+    }
+
+    /**
+     * Confirm that FileAlreadyExistsException is thrown entity is empty
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testMove_entityEmpty() throws Exception {
+        File newTmpFile = generateTemporaryFile();
+        String targetString = tempFolder.getRoot().toString() + "/testmove/test_tmp_object.tmp";
+        File targetFile = new File(targetString);
+        this.fileHashStore.move(newTmpFile, targetFile, "");
+    }
+
+    /**
+     * Confirm that FileAlreadyExistsException is thrown when entity is empty spaces
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testMove_entityEmptySpaces() throws Exception {
+        File newTmpFile = generateTemporaryFile();
+        String targetString = tempFolder.getRoot().toString() + "/testmove/test_tmp_object.tmp";
+        File targetFile = new File(targetString);
+        this.fileHashStore.move(newTmpFile, targetFile, "     ");
+    }
+
+    /**
      * Test putMetadata stores metadata as expected
      */
     @Test

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -461,7 +461,7 @@ public class FileHashStoreProtectedTest {
      * Check that default checksums are generated
      */
     @Test
-    public void writeToTempFileAndGenerateChecksums() throws Exception {
+    public void writeToTmpFileAndGenerateChecksums() throws Exception {
         for (String pid : testData.pidList) {
             File newTmpFile = generateTemporaryFile();
             String pidFormatted = pid.replace("/", "_");
@@ -471,10 +471,8 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             Map<String, String> hexDigests = this.fileHashStore.writeToTmpFileAndGenerateChecksums(newTmpFile,
-                    dataStream,
-                    null, null);
+                    dataStream, null, null);
 
-            System.out.println(hexDigests);
             // Validate checksum values
             String md5 = testData.pidData.get(pid).get("md5");
             String sha1 = testData.pidData.get(pid).get("sha1");
@@ -490,67 +488,10 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
-     * Check that checksums are generated when additional algorithm supplied.
-     */
-    @Test
-    public void writeToTempFileAndGenerateChecksums_addAlgo() throws Exception {
-        for (String pid : testData.pidList) {
-            File newTmpFile = generateTemporaryFile();
-            String pidFormatted = pid.replace("/", "_");
-
-            // Get test file
-            Path testDataFile = testData.getTestFile(pidFormatted);
-
-            // Extra algo to calculate - MD2
-            String addAlgo = "MD2";
-
-            InputStream dataStream = Files.newInputStream(testDataFile);
-            Map<String, String> hexDigests = this.fileHashStore.writeToTmpFileAndGenerateChecksums(newTmpFile,
-                    dataStream,
-                    addAlgo, null);
-
-            // Validate checksum values
-            String md2 = testData.pidData.get(pid).get("md2");
-            assertEquals(md2, hexDigests.get("MD2"));
-        }
-    }
-
-    /**
-     * Check that checksums are generated when both additional and checksum
-     * algorithm supplied
-     */
-    @Test
-    public void writeToTempFileAndGenerateChecksums_addAlgoChecksumAlgo() throws Exception {
-        for (String pid : testData.pidList) {
-            File newTmpFile = generateTemporaryFile();
-            String pidFormatted = pid.replace("/", "_");
-
-            // Get test file
-            Path testDataFile = testData.getTestFile(pidFormatted);
-
-            // Extra algo to calculate - MD2
-            String addAlgo = "MD2";
-            String checksumAlgo = "SHA-512/224";
-
-            InputStream dataStream = Files.newInputStream(testDataFile);
-            Map<String, String> hexDigests = this.fileHashStore.writeToTmpFileAndGenerateChecksums(newTmpFile,
-                    dataStream,
-                    addAlgo, checksumAlgo);
-
-            System.out.println(hexDigests);
-            // Validate checksum values
-            String md2 = testData.pidData.get(pid).get("md2");
-            String sha512224 = testData.pidData.get(pid).get("sha512-224");
-            assertEquals(md2, hexDigests.get("MD2"));
-            assertEquals(sha512224, hexDigests.get("SHA-512/224"));
-        }
-    }
-
-    /**
      * Check that the temporary file that has been written into is not empty
      */
     @Test
-    public void writeToTempFileAndGenerateChecksums_tmpFileSize() throws Exception {
+    public void writeToTmpFileAndGenerateChecksums_tmpFileSize() throws Exception {
         for (String pid : testData.pidList) {
             File newTmpFile = generateTemporaryFile();
             String pidFormatted = pid.replace("/", "_");
@@ -565,9 +506,87 @@ public class FileHashStoreProtectedTest {
             this.fileHashStore.writeToTmpFileAndGenerateChecksums(newTmpFile, dataStream, addAlgo, null);
 
             long testDataFileSize = Files.size(testDataFile);
-            Path tmpFilePath = newTmpFile.toPath();
-            long tmpFileSize = Files.size(tmpFilePath);
+            long tmpFileSize = Files.size(newTmpFile.toPath());
             assertEquals(testDataFileSize, tmpFileSize);
+        }
+    }
+
+    /**
+     * Check that checksums are generated when additional algorithm supplied.
+     */
+    @Test
+    public void writeToTmpFileAndGenerateChecksums_addAlgo() throws Exception {
+        for (String pid : testData.pidList) {
+            File newTmpFile = generateTemporaryFile();
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test file
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            // Extra algo to calculate - MD2
+            String addAlgo = "MD2";
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            Map<String, String> hexDigests = this.fileHashStore.writeToTmpFileAndGenerateChecksums(newTmpFile,
+                    dataStream, addAlgo, null);
+
+            // Validate checksum values
+            String md2 = testData.pidData.get(pid).get("md2");
+            assertEquals(md2, hexDigests.get("MD2"));
+        }
+    }
+
+    /**
+     * Check that checksums are generated when checksum algorithm supplied
+     */
+    @Test
+    public void writeToTmpFileAndGenerateChecksums_checksumAlgo() throws Exception {
+        for (String pid : testData.pidList) {
+            File newTmpFile = generateTemporaryFile();
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test file
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            // Extra algo to calculate - MD2
+            String checksumAlgo = "SHA-512/224";
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            Map<String, String> hexDigests = this.fileHashStore.writeToTmpFileAndGenerateChecksums(newTmpFile,
+                    dataStream, null, checksumAlgo);
+
+            // Validate checksum values
+            String sha512224 = testData.pidData.get(pid).get("sha512-224");
+            assertEquals(sha512224, hexDigests.get("SHA-512/224"));
+        }
+    }
+
+    /**
+     * Check that checksums are generated when both additional and checksum
+     * algorithm supplied
+     */
+    @Test
+    public void writeToTmpFileAndGenerateChecksums_addAlgoChecksumAlgo() throws Exception {
+        for (String pid : testData.pidList) {
+            File newTmpFile = generateTemporaryFile();
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test file
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            // Extra algo to calculate - MD2
+            String addAlgo = "MD2";
+            String checksumAlgo = "SHA-512/224";
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            Map<String, String> hexDigests = this.fileHashStore.writeToTmpFileAndGenerateChecksums(newTmpFile,
+                    dataStream, addAlgo, checksumAlgo);
+
+            // Validate checksum values
+            String md2 = testData.pidData.get(pid).get("md2");
+            String sha512224 = testData.pidData.get(pid).get("sha512-224");
+            assertEquals(md2, hexDigests.get("MD2"));
+            assertEquals(sha512224, hexDigests.get("SHA-512/224"));
         }
     }
 
@@ -575,7 +594,7 @@ public class FileHashStoreProtectedTest {
      * Check that exception is thrown when unsupported algorithm supplied
      */
     @Test(expected = NoSuchAlgorithmException.class)
-    public void writeToTempFileAndGenerateChecksums_invalidAlgo() throws Exception {
+    public void writeToTmpFileAndGenerateChecksums_invalidAlgo() throws Exception {
         for (String pid : testData.pidList) {
             File newTmpFile = generateTemporaryFile();
             String pidFormatted = pid.replace("/", "_");
@@ -616,5 +635,45 @@ public class FileHashStoreProtectedTest {
 
         File newTmpFileTwo = generateTemporaryFile();
         this.fileHashStore.move(newTmpFileTwo, targetFile);
+    }
+
+    /**
+     * Check that tmp metadata is written with good data
+     */
+    @Test
+    public void writeToTmpMetadataFile() throws Exception {
+        for (String pid : testData.pidList) {
+            File newTmpFile = generateTemporaryFile();
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test metadata file
+            Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
+
+            InputStream metadataStream = Files.newInputStream(testMetaDataFile);
+            boolean metadataWritten = this.fileHashStore.writeToTmpMetadataFile(newTmpFile, metadataStream);
+            assertTrue(metadataWritten);
+        }
+    }
+
+    /**
+     * Check that tmp metadata is actually written by verifying file size
+     */
+    @Test
+    public void writeToTmpMetadataFile_tmpFileSize() throws Exception {
+        for (String pid : testData.pidList) {
+            File newTmpFile = generateTemporaryFile();
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test metadata file
+            Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
+
+            InputStream metadataStream = Files.newInputStream(testMetaDataFile);
+            boolean metadataWritten = this.fileHashStore.writeToTmpMetadataFile(newTmpFile, metadataStream);
+            assertTrue(metadataWritten);
+
+            long testMetadataFileSize = Files.size(testMetaDataFile);
+            long tmpMetadataFileSize = Files.size(newTmpFile.toPath());
+            assertEquals(testMetadataFileSize, tmpMetadataFileSize);
+        }
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -25,6 +25,8 @@ public class FileHashStorePublicTest {
     private static Path rootDirectory;
     private static Path objStringFull;
     private static Path objTmpStringFull;
+    private static Path metadataStringFull;
+    private static Path metadataTmpStringFull;
     private static FileHashStore fileHashStore;
     private static final TestDataHarness testData = new TestDataHarness();
 
@@ -37,12 +39,15 @@ public class FileHashStorePublicTest {
         rootDirectory = root.resolve("metacat");
         objStringFull = rootDirectory.resolve("objects");
         objTmpStringFull = rootDirectory.resolve("objects/tmp");
+        metadataStringFull = rootDirectory.resolve("metadata");
+        metadataTmpStringFull = rootDirectory.resolve("metadata/tmp");
 
         HashMap<String, Object> storeProperties = new HashMap<>();
         storeProperties.put("storePath", rootDirectory);
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
 
         try {
             fileHashStore = new FileHashStore(storeProperties);
@@ -61,24 +66,6 @@ public class FileHashStorePublicTest {
     public static TemporaryFolder tempFolder = new TemporaryFolder();
 
     /**
-     * Check object store directory are created after initialization
-     */
-    @Test
-    public void initObjDirectory() {
-        Path checkStorePath = objStringFull;
-        assertTrue(Files.isDirectory(checkStorePath));
-    }
-
-    /**
-     * Check object store tmp directory are created after initialization
-     */
-    @Test
-    public void initObjTmpDirectory() {
-        Path checkTmpPath = objTmpStringFull;
-        assertTrue(Files.isDirectory(checkTmpPath));
-    }
-
-    /**
      * Test invalid depth value
      */
     @Test(expected = IllegalArgumentException.class)
@@ -88,6 +75,7 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 0);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
         new FileHashStore(storeProperties);
     }
 
@@ -101,6 +89,7 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 2);
         storeProperties.put("storeWidth", 0);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
         new FileHashStore(storeProperties);
     }
 
@@ -114,6 +103,63 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 2);
         storeProperties.put("storeWidth", 0);
         storeProperties.put("storeAlgorithm", "SM2");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test empty algorithm throws exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_emptyAlgorithmArg() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", Paths.get("/test/path"));
+        storeProperties.put("storeDepth", 2);
+        storeProperties.put("storeWidth", 3);
+        storeProperties.put("storeAlgorithm", "");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test algorithm with empty spaces throws exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_emptySpacesAlgorithmArg() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", Paths.get("/test/path"));
+        storeProperties.put("storeDepth", 2);
+        storeProperties.put("storeWidth", 3);
+        storeProperties.put("storeAlgorithm", "       ");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test empty metadata formatId value
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_emptyMetadataNameSpaceArg() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", Paths.get("/test/path"));
+        storeProperties.put("storeDepth", 2);
+        storeProperties.put("storeWidth", 0);
+        storeProperties.put("storeAlgorithm", "MD5");
+        storeProperties.put("storeMetadataNamespace", "");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test metadata formatId with empty spaces
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_emptySpacesMetadataNameSpaceArg() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", Paths.get("/test/path"));
+        storeProperties.put("storeDepth", 2);
+        storeProperties.put("storeWidth", 0);
+        storeProperties.put("storeAlgorithm", "MD5");
+        storeProperties.put("storeMetadataNamespace", "     ");
         new FileHashStore(storeProperties);
     }
 
@@ -127,7 +173,44 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
         new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Check object store directory is created after initialization
+     */
+    @Test
+    public void initObjDirectory() {
+        Path checkObjectStorePath = objStringFull;
+        assertTrue(Files.isDirectory(checkObjectStorePath));
+    }
+
+    /**
+     * Check object store tmp directory is created after initialization
+     */
+    @Test
+    public void initObjTmpDirectory() {
+        Path checkTmpPath = objTmpStringFull;
+        assertTrue(Files.isDirectory(checkTmpPath));
+    }
+
+    /**
+     * Check metadata store directory is created after initialization
+     */
+    @Test
+    public void initMetadataDirectory() {
+        Path checkMetadataStorePath = metadataStringFull;
+        assertTrue(Files.isDirectory(checkMetadataStorePath));
+    }
+
+    /**
+     * Check metadata store tmp directory is created after initialization
+     */
+    @Test
+    public void initMetadataTmpDirectory() {
+        Path checkMetadataTmpPath = metadataTmpStringFull;
+        assertTrue(Files.isDirectory(checkMetadataTmpPath));
     }
 
     /**
@@ -149,6 +232,7 @@ public class FileHashStorePublicTest {
         assertEquals(hsProperties.get("storeDepth"), 3);
         assertEquals(hsProperties.get("storeWidth"), 2);
         assertEquals(hsProperties.get("storeAlgorithm"), "SHA-256");
+        assertEquals(hsProperties.get("storeMetadataNamespace"), "http://ns.dataone.org/service/types/v2.0");
     }
 
     /**
@@ -161,6 +245,7 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
         new FileHashStore(storeProperties);
     }
 
@@ -175,6 +260,7 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "MD5");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
         new FileHashStore(storeProperties);
     }
 
@@ -189,6 +275,7 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 2);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
         new FileHashStore(storeProperties);
     }
 
@@ -203,6 +290,22 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 1);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
+        new FileHashStore(storeProperties);
+    }
+
+    /**
+     * Test existing configuration file will raise exception when metadata formatId
+     * is different when instantiating FileHashStore
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testExistingHashStoreConfiguration_diffMetadataNamespace() throws Exception {
+        HashMap<String, Object> storeProperties = new HashMap<>();
+        storeProperties.put("storePath", rootDirectory);
+        storeProperties.put("storeDepth", 3);
+        storeProperties.put("storeWidth", 1);
+        storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.metadata.org/types/v2.0");
         new FileHashStore(storeProperties);
     }
 
@@ -219,6 +322,7 @@ public class FileHashStorePublicTest {
         storeProperties.put("storeDepth", 3);
         storeProperties.put("storeWidth", 2);
         storeProperties.put("storeAlgorithm", "SHA-256");
+        storeProperties.put("storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0");
         FileHashStore secondHashStore = new FileHashStore(storeProperties);
 
         // Confirm config present

--- a/src/test/java/org/dataone/hashstore/testdata/TestDataHarness.java
+++ b/src/test/java/org/dataone/hashstore/testdata/TestDataHarness.java
@@ -10,56 +10,59 @@ import java.util.Map;
  * This class returns the test data expected hex digest values
  */
 public class TestDataHarness {
-    public Map<String, Map<String, String>> pidData;
-    public String[] pidList = { "doi:10.18739/A2901ZH2M", "jtao.1700.1",
-            "urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a" };
+        public Map<String, Map<String, String>> pidData;
+        public String[] pidList = { "doi:10.18739/A2901ZH2M", "jtao.1700.1",
+                        "urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a" };
 
-    public TestDataHarness() {
-        Map<String, Map<String, String>> pidsAndHexDigests = new HashMap<>();
+        public TestDataHarness() {
+                Map<String, Map<String, String>> pidsAndHexDigests = new HashMap<>();
 
-        Map<String, String> values1 = new HashMap<>();
-        values1.put("s_cid", "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e");
-        values1.put("md2", "b33c730ac5e36b2b886a9cd14552f42e");
-        values1.put("md5", "db91c910a3202478c8def1071c54aae5");
-        values1.put("sha1", "1fe86e3c8043afa4c70857ca983d740ad8501ccd");
-        values1.put("sha256", "4d198171eef969d553d4c9537b1811a7b078f9a3804fc978a761bc014c05972c");
-        values1.put("sha384",
-                "d5953bd802fa74edea72eb941ead7a27639e62792fedc065d6c81de6c613b5b8739ab1f90e7f24a7500d154a727ed7c2");
-        values1.put("sha512",
-                "e9bcd6b91b102ef5803d1bd60c7a5d2dbec1a2baf5f62f7da60de07607ad6797d6a9b740d97a257fd2774f2c26503d455d8f2a03a128773477dfa96ab96a2e54");
-        pidsAndHexDigests.put("doi:10.18739/A2901ZH2M", values1);
+                Map<String, String> values1 = new HashMap<>();
+                values1.put("s_cid", "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e");
+                values1.put("md2", "b33c730ac5e36b2b886a9cd14552f42e");
+                values1.put("md5", "db91c910a3202478c8def1071c54aae5");
+                values1.put("sha1", "1fe86e3c8043afa4c70857ca983d740ad8501ccd");
+                values1.put("sha256", "4d198171eef969d553d4c9537b1811a7b078f9a3804fc978a761bc014c05972c");
+                values1.put("sha384",
+                                "d5953bd802fa74edea72eb941ead7a27639e62792fedc065d6c81de6c613b5b8739ab1f90e7f24a7500d154a727ed7c2");
+                values1.put("sha512",
+                                "e9bcd6b91b102ef5803d1bd60c7a5d2dbec1a2baf5f62f7da60de07607ad6797d6a9b740d97a257fd2774f2c26503d455d8f2a03a128773477dfa96ab96a2e54");
+                values1.put("sha512-224", "107f9facb268471de250625440b6c8b7ff8296fbe5d89bed4a61fd35");
+                pidsAndHexDigests.put("doi:10.18739/A2901ZH2M", values1);
 
-        Map<String, String> values2 = new HashMap<>();
-        values2.put("s_cid", "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf");
-        values2.put("md2", "9c25df1c8ba1d2e57bb3fd4785878b85");
-        values2.put("md5", "f4ea2d07db950873462a064937197b0f");
-        values2.put("sha1", "3d25436c4490b08a2646e283dada5c60e5c0539d");
-        values2.put("sha256", "94f9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a");
-        values2.put("sha384",
-                "a204678330fcdc04980c9327d4e5daf01ab7541e8a351d49a7e9c5005439dce749ada39c4c35f573dd7d307cca11bea8");
-        values2.put("sha512",
-                "bf9e7f4d4e66bd082817d87659d1d57c2220c376cd032ed97cadd481cf40d78dd479cbed14d34d98bae8cebc603b40c633d088751f07155a94468aa59e2ad109");
-        pidsAndHexDigests.put("jtao.1700.1", values2);
+                Map<String, String> values2 = new HashMap<>();
+                values2.put("s_cid", "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf");
+                values2.put("md2", "9c25df1c8ba1d2e57bb3fd4785878b85");
+                values2.put("md5", "f4ea2d07db950873462a064937197b0f");
+                values2.put("sha1", "3d25436c4490b08a2646e283dada5c60e5c0539d");
+                values2.put("sha256", "94f9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a");
+                values2.put("sha384",
+                                "a204678330fcdc04980c9327d4e5daf01ab7541e8a351d49a7e9c5005439dce749ada39c4c35f573dd7d307cca11bea8");
+                values2.put("sha512",
+                                "bf9e7f4d4e66bd082817d87659d1d57c2220c376cd032ed97cadd481cf40d78dd479cbed14d34d98bae8cebc603b40c633d088751f07155a94468aa59e2ad109");
+                values2.put("sha512-224", "7a2b22e36ced9e91cf8cdf6971897ec4ae21780e11d1c3903011af33");
+                pidsAndHexDigests.put("jtao.1700.1", values2);
 
-        Map<String, String> values3 = new HashMap<>();
-        values3.put("s_cid", "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6");
-        values3.put("md2", "9f2b06b300f661ce4398006c41d8aa88");
-        values3.put("md5", "e1932fc75ca94de8b64f1d73dc898079");
-        values3.put("sha1", "c6d2a69a3f5adaf478ba796c114f57b990cf7ad1");
-        values3.put("sha256", "4473516a592209cbcd3a7ba4edeebbdb374ee8e4a49d19896fafb8f278dc25fa");
-        values3.put("sha384",
-                "b1023a9be5aa23a102be9bce66e71f1f1c7a6b6b03e3fc603e9cd36b4265671e94f9cc5ce3786879740536994489bc26");
-        values3.put("sha512",
-                "c7fac7e8aacde8546ddb44c640ad127df82830bba6794aea9952f737c13a81d69095865ab3018ed2a807bf9222f80657faf31cfde6c853d7b91e617e148fec76");
-        pidsAndHexDigests.put("urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a", values3);
+                Map<String, String> values3 = new HashMap<>();
+                values3.put("s_cid", "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6");
+                values3.put("md2", "9f2b06b300f661ce4398006c41d8aa88");
+                values3.put("md5", "e1932fc75ca94de8b64f1d73dc898079");
+                values3.put("sha1", "c6d2a69a3f5adaf478ba796c114f57b990cf7ad1");
+                values3.put("sha256", "4473516a592209cbcd3a7ba4edeebbdb374ee8e4a49d19896fafb8f278dc25fa");
+                values3.put("sha384",
+                                "b1023a9be5aa23a102be9bce66e71f1f1c7a6b6b03e3fc603e9cd36b4265671e94f9cc5ce3786879740536994489bc26");
+                values3.put("sha512",
+                                "c7fac7e8aacde8546ddb44c640ad127df82830bba6794aea9952f737c13a81d69095865ab3018ed2a807bf9222f80657faf31cfde6c853d7b91e617e148fec76");
+                values3.put("sha512-224", "e1789a91c9df334fdf6ee5d295932ad96028c426a18b17016a627099");
+                pidsAndHexDigests.put("urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a", values3);
 
-        this.pidData = pidsAndHexDigests;
-    }
+                this.pidData = pidsAndHexDigests;
+        }
 
-    public Path getTestFile(String pid) {
-        Path testdataDirectory = Paths.get("src/test/java/org/dataone/hashstore", "testdata", pid);
-        String testdataAbsolutePath = testdataDirectory.toFile().getAbsolutePath();
-        Path testDataFile = new File(testdataAbsolutePath).toPath();
-        return testDataFile;
-    }
+        public Path getTestFile(String pid) {
+                Path testdataDirectory = Paths.get("src/test/java/org/dataone/hashstore", "testdata", pid);
+                String testdataAbsolutePath = testdataDirectory.toFile().getAbsolutePath();
+                Path testDataFile = new File(testdataAbsolutePath).toPath();
+                return testDataFile;
+        }
 }


### PR DESCRIPTION
Summary of Changes:
- Implement `storeMetadata()`Public API method in `FileHashStore`  (plus other supporting protected methods)
- Add junit tests to ensure all new methods are behaving as expected, including confirming that header and body sections are correctly written and that calling `storeMetadata()` on the same `hash(id+formatId)` only writes one file in total without any collisions (pid synchronization)
- Bug fix and updated junit tests for `storeObject` where `checksumAlgorithm` is supplied but never utilized in `writeToTmpFileAndGenerateChecksums`