### PR TITLE
Feature-29: Add 'deleteObject', 'deleteMetadata' and 'getHexDigest' Public API Methods

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,5 +8,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/src/main/java/org/dataone/hashstore/HashAddress.java
+++ b/src/main/java/org/dataone/hashstore/HashAddress.java
@@ -11,11 +11,11 @@ import java.util.Map;
  * know the underlying file system details.
  */
 public class HashAddress {
-    private String id;
-    private String relPath;
-    private Path absPath;
-    private boolean isDuplicate;
-    private Map<String, String> hexDigests;
+    private final String id;
+    private final String relPath;
+    private final Path absPath;
+    private final boolean isDuplicate;
+    private final Map<String, String> hexDigests;
 
     /**
      * Creates a new instance of HashAddress with the given properties.

--- a/src/main/java/org/dataone/hashstore/HashAddress.java
+++ b/src/main/java/org/dataone/hashstore/HashAddress.java
@@ -1,5 +1,6 @@
 package org.dataone.hashstore;
 
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -12,7 +13,7 @@ import java.util.Map;
 public class HashAddress {
     private String id;
     private String relPath;
-    private String absPath;
+    private Path absPath;
     private boolean isDuplicate;
     private Map<String, String> hexDigests;
 
@@ -27,7 +28,7 @@ public class HashAddress {
      * @param hexDigests  a map of hash algorithm names to their hex-encoded
      *                    digest values for the file
      */
-    public HashAddress(String id, String relPath, String absPath, boolean isDuplicate,
+    public HashAddress(String id, String relPath, Path absPath, boolean isDuplicate,
             Map<String, String> hexDigests) {
         // Constructor implementation
         this.id = id;
@@ -60,7 +61,7 @@ public class HashAddress {
      * 
      * @return absolute path
      */
-    public String getAbsPath() {
+    public Path getAbsPath() {
         return absPath;
     }
 

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -105,7 +105,7 @@ public interface HashStore {
          * @throws FileNotFoundException    When requested pid has no associated object
          * @throws IOException              I/O error when creating InputStream to
          *                                  object
-         * @throws NoSuchAlgorithmException When algorithm used to calcualte object
+         * @throws NoSuchAlgorithmException When algorithm used to calculate object
          *                                  address is not supported
          */
         InputStream retrieveObject(String pid)
@@ -123,21 +123,21 @@ public interface HashStore {
          *                                  associated object
          * @throws IOException              I/O error when creating InputStream to
          *                                  metadata
-         * @throws NoSuchAlgorithmException When algorithm used to calcualte metadata
+         * @throws NoSuchAlgorithmException When algorithm used to calculate metadata
          *                                  address is not supported
          */
         InputStream retrieveMetadata(String pid, String formatId) throws Exception;
 
         /**
          * The 'deleteObject' method deletes an object permanently from disk using a
-         * given persistent identifier and any empty subdirecetories.
+         * given persistent identifier and any empty subdirectories.
          * 
          * @param pid Authority-based identifier
-         * @return
+         * @return True if successful
          * @throws IllegalArgumentException When pid is null or empty
          * @throws FileNotFoundException    When requested pid has no associated object
          * @throws IOException              I/O error when deleting empty directories
-         * @throws NoSuchAlgorithmException When algorithm used to calcualte object
+         * @throws NoSuchAlgorithmException When algorithm used to calculate object
          *                                  address is not supported
          */
         boolean deleteObject(String pid) throws Exception;
@@ -149,11 +149,11 @@ public interface HashStore {
          * 
          * @param pid      Authority-based identifier
          * @param formatId Metadata namespace/format
-         * @return
+         * @return True if successfulÏ
          * @throws IllegalArgumentException When pid or formatId is null or empty
          * @throws FileNotFoundException    When requested pid has no metadata
          * @throws IOException              I/O error when deleting empty directories
-         * @throws NoSuchAlgorithmException When algorithm used to calcualte object
+         * @throws NoSuchAlgorithmException When algorithm used to calculate object
          *                                  address is not supported
          */
         boolean deleteMetadata(String pid, String formatId) throws Exception;
@@ -164,8 +164,12 @@ public interface HashStore {
          * 
          * @param pid       Authority-based identifier
          * @param algorithm Algorithm of desired hex digest
-         * @return
-         * @throws Exception TODO: Add specific exceptions
+         * @return String hex digest of requested pid
+         * @throws IllegalArgumentException When pid or formatId is null or empty
+         * @throws FileNotFoundException    When requested pid object does not exist
+         * @throws IOException              I/O error when calculating hex digests
+         * @throws NoSuchAlgorithmException When algorithm used to calculate object
+         *                                  address is not supported
          */
         String getHexDigest(String pid, String algorithm) throws Exception;
 }

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -130,11 +130,15 @@ public interface HashStore {
 
         /**
          * The 'deleteObject' method deletes an object permanently from disk using a
-         * given persistent identifier.
+         * given persistent identifier and any empty subdirecetories.
          * 
          * @param pid Authority-based identifier
          * @return
-         * @throws Exception TODO: Add specific exceptions
+         * @throws IllegalArgumentException When pid is null or empty
+         * @throws FileNotFoundException    When requested pid has no associated object
+         * @throws IOException              I/O error when deleting empty directories
+         * @throws NoSuchAlgorithmException When algorithm used to calcualte object
+         *                                  address is not supported
          */
         boolean deleteObject(String pid) throws Exception;
 

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -150,7 +150,11 @@ public interface HashStore {
          * @param pid      Authority-based identifier
          * @param formatId Metadata namespace/format
          * @return
-         * @throws Exception TODO: Add specific exceptions
+         * @throws IllegalArgumentException When pid or formatId is null or empty
+         * @throws FileNotFoundException    When requested pid has no metadata
+         * @throws IOException              I/O error when deleting empty directories
+         * @throws NoSuchAlgorithmException When algorithm used to calcualte object
+         *                                  address is not supported
          */
         boolean deleteMetadata(String pid, String formatId) throws Exception;
 

--- a/src/main/java/org/dataone/hashstore/HashStoreFactory.java
+++ b/src/main/java/org/dataone/hashstore/HashStoreFactory.java
@@ -26,8 +26,8 @@ public class HashStoreFactory {
      *                        (int)
      *                        storeAlgorithm
      * 
-     * @return
-     * @throws HashStoreFactoryException When HashStore fails to initialize due to
+     * @return HashStore instance ready to store objects and metadata
+     * @throws HashStoreFactoryException When HashStore failÏs to initialize due to
      *                                   permissions or class-related issues
      * @throws IOException               When there is an issue with properties
      */

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -609,7 +609,8 @@ public class FileHashStore implements HashStore {
     }
 
     @Override
-    public boolean deleteObject(String pid) throws Exception {
+    public boolean deleteObject(String pid)
+            throws IllegalArgumentException, FileNotFoundException, IOException, NoSuchAlgorithmException {
         logFileHashStore.debug("FileHashStore.deleteObject - Called to delete object for pid: " + pid);
 
         if (pid == null || pid.trim().isEmpty()) {

--- a/src/test/java/org/dataone/hashstore/HashAddressTest.java
+++ b/src/test/java/org/dataone/hashstore/HashAddressTest.java
@@ -1,5 +1,7 @@
 package org.dataone.hashstore;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,7 +17,7 @@ import org.junit.Test;
 public class HashAddressTest {
     private static String id = "";
     private static String relpath = "";
-    private static String abspath = "";
+    private static Path abspath;
     private static boolean isDuplicate;
     private static Map<String, String> hexDigests;
 
@@ -26,7 +28,7 @@ public class HashAddressTest {
     public static void initializeInstanceVariables() {
         id = "94f9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a";
         relpath = "/rel/test/directory";
-        abspath = "/abs/test/directory";
+        abspath = Paths.get("/abs/test/directory");
         isDuplicate = true;
         hexDigests = new HashMap<>();
         hexDigests.put("md5", "f4ea2d07db950873462a064937197b0f");
@@ -73,7 +75,7 @@ public class HashAddressTest {
     @Test
     public void testHashAddressGetAbsPath() {
         HashAddress hashad = new HashAddress(id, relpath, abspath, isDuplicate, hexDigests);
-        String hashad_abspath = hashad.getAbsPath();
+        Path hashad_abspath = hashad.getAbsPath();
         assertEquals(hashad_abspath, abspath);
     }
 

--- a/src/test/java/org/dataone/hashstore/HashStoreTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreTest.java
@@ -99,7 +99,7 @@ public class HashStoreTest {
             // Check id (sha-256 hex digest of the ab_id, aka object_cid)
             String objAuthorityId = testData.pidData.get(pid).get("object_cid");
             assertEquals(objAuthorityId, objInfo.getId());
-            assertTrue(Files.exists(Paths.get(objInfo.getAbsPath())));
+            assertTrue(Files.exists(objInfo.getAbsPath()));
         }
     }
 }

--- a/src/test/java/org/dataone/hashstore/HashStoreTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.fail;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 
 import org.dataone.hashstore.exceptions.HashStoreFactoryException;

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -1,6 +1,5 @@
 package org.dataone.hashstore.filehashstore;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -664,12 +664,8 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveObject_pidNull() throws Exception {
-        try {
-            InputStream pidInputStream = fileHashStore.retrieveObject(null);
-            pidInputStream.close();
-        } catch (Exception e) {
-            throw e;
-        }
+        InputStream pidInputStream = fileHashStore.retrieveObject(null);
+        pidInputStream.close();
     }
 
     /**
@@ -677,12 +673,8 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveObject_pidEmpty() throws Exception {
-        try {
-            InputStream pidInputStream = fileHashStore.retrieveObject("");
-            pidInputStream.close();
-        } catch (Exception e) {
-            throw e;
-        }
+        InputStream pidInputStream = fileHashStore.retrieveObject("");
+        pidInputStream.close();
     }
 
     /**
@@ -690,12 +682,8 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveObject_pidEmptySpaces() throws Exception {
-        try {
-            InputStream pidInputStream = fileHashStore.retrieveObject("      ");
-            pidInputStream.close();
-        } catch (Exception e) {
-            throw e;
-        }
+        InputStream pidInputStream = fileHashStore.retrieveObject("      ");
+        pidInputStream.close();
     }
 
     /**
@@ -703,12 +691,8 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = FileNotFoundException.class)
     public void retrieveObject_pidNotFound() throws Exception {
-        try {
-            InputStream pidInputStream = fileHashStore.retrieveObject("dou.2023.hs.1");
-            pidInputStream.close();
-        } catch (Exception e) {
-            throw e;
-        }
+        InputStream pidInputStream = fileHashStore.retrieveObject("dou.2023.hs.1");
+        pidInputStream.close();
     }
 
     /**
@@ -781,14 +765,10 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveMetadata_pidNull() throws Exception {
-        try {
-            String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
-            InputStream pidInputStream = fileHashStore.retrieveMetadata(null, storeFormatId);
-            pidInputStream.close();
+        String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
+        InputStream pidInputStream = fileHashStore.retrieveMetadata(null, storeFormatId);
+        pidInputStream.close();
 
-        } catch (Exception e) {
-            throw e;
-        }
     }
 
     /**
@@ -796,14 +776,10 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveMetadata_pidEmpty() throws Exception {
-        try {
-            String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
-            InputStream pidInputStream = fileHashStore.retrieveMetadata("", storeFormatId);
-            pidInputStream.close();
+        String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
+        InputStream pidInputStream = fileHashStore.retrieveMetadata("", storeFormatId);
+        pidInputStream.close();
 
-        } catch (Exception e) {
-            throw e;
-        }
     }
 
     /**
@@ -811,14 +787,10 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveMetadata_pidEmptySpaces() throws Exception {
-        try {
-            String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
-            InputStream pidInputStream = fileHashStore.retrieveMetadata("      ", storeFormatId);
-            pidInputStream.close();
+        String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
+        InputStream pidInputStream = fileHashStore.retrieveMetadata("      ", storeFormatId);
+        pidInputStream.close();
 
-        } catch (Exception e) {
-            throw e;
-        }
     }
 
     /**
@@ -826,13 +798,9 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveMetadata_formatNull() throws Exception {
-        try {
-            InputStream pidInputStream = fileHashStore.retrieveMetadata("dou.2023.hs.1", null);
-            pidInputStream.close();
+        InputStream pidInputStream = fileHashStore.retrieveMetadata("dou.2023.hs.1", null);
+        pidInputStream.close();
 
-        } catch (Exception e) {
-            throw e;
-        }
     }
 
     /**
@@ -840,13 +808,9 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveMetadata_formatEmpty() throws Exception {
-        try {
-            InputStream pidInputStream = fileHashStore.retrieveMetadata("dou.2023.hs.1", "");
-            pidInputStream.close();
+        InputStream pidInputStream = fileHashStore.retrieveMetadata("dou.2023.hs.1", "");
+        pidInputStream.close();
 
-        } catch (Exception e) {
-            throw e;
-        }
     }
 
     /**
@@ -854,13 +818,9 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void retrieveMetadata_formatEmptySpaces() throws Exception {
-        try {
-            InputStream pidInputStream = fileHashStore.retrieveMetadata("dou.2023.hs.1", "      ");
-            pidInputStream.close();
+        InputStream pidInputStream = fileHashStore.retrieveMetadata("dou.2023.hs.1", "      ");
+        pidInputStream.close();
 
-        } catch (Exception e) {
-            throw e;
-        }
     }
 
     /**
@@ -868,14 +828,10 @@ public class FileHashStoreInterfaceTest {
      */
     @Test(expected = FileNotFoundException.class)
     public void retrieveMetadata_pidNotFound() throws Exception {
-        try {
-            String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
-            InputStream pidInputStream = fileHashStore.retrieveMetadata("dou.2023.hs.1", storeFormatId);
-            pidInputStream.close();
+        String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
+        InputStream pidInputStream = fileHashStore.retrieveMetadata("dou.2023.hs.1", storeFormatId);
+        pidInputStream.close();
 
-        } catch (Exception e) {
-            throw e;
-        }
     }
 
     /**
@@ -927,7 +883,7 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Confirm that deleteObject deletes object and empty sub directories
+     * Confirm that deleteObject deletes object and empty subdirectories
      */
     @Test
     public void deleteObject() throws Exception {
@@ -1079,5 +1035,79 @@ public class FileHashStoreInterfaceTest {
     public void deleteMetadata_formatIdEmptySpaces() throws Exception {
         String pid = "dou.2023.hashstore.1";
         fileHashStore.deleteMetadata(pid, "     ");
+    }
+
+    /**
+     * Confirm correct checksum/hex digest returned
+     */
+    @Test
+    public void getHexDigest() throws Exception {
+        for (String pid : testData.pidList) {
+            // Store file first
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+
+            // Then get the checksum
+            String pidHexDigest = fileHashStore.getHexDigest(pid, "SHA-256");
+            String sha256DigestFromTestData = testData.pidData.get(pid).get("sha256");
+            String objSha256Checksum = objInfo.getHexDigests().get("SHA-256");
+            assertEquals(pidHexDigest, sha256DigestFromTestData);
+            assertEquals(pidHexDigest, objSha256Checksum);
+        }
+    }
+
+    /**
+     * Confirm getHexDigest throws exception when file is not found
+     */
+    @Test(expected = FileNotFoundException.class)
+    public void getHexDigest_pidNotFound() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            fileHashStore.getHexDigest(pidFormatted, "SHA-256");
+        }
+    }
+
+    /**
+     * Confirm getHexDigest throws exception when file is not found
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void getHexDigest_pidNull() throws Exception {
+        fileHashStore.getHexDigest(null, "SHA-256");
+    }
+
+    /**
+     * Confirm getHexDigest throws exception when file is not found
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void getHexDigest_pidEmpty() throws Exception {
+        fileHashStore.getHexDigest("", "SHA-256");
+    }
+
+    /**
+     * Confirm getHexDigest throws exception when file is not found
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void getHexDigest_pidEmptySpaces() throws Exception {
+        fileHashStore.getHexDigest("      ", "SHA-256");
+    }
+
+    /**
+     * Confirm getHexDigest throws exception when unsupported algorithm supplied
+     */
+    @Test(expected = NoSuchAlgorithmException.class)
+    public void getHexDigest_badAlgo() throws Exception {
+        for (String pid : testData.pidList) {
+            // Store object first
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            fileHashStore.storeObject(dataStream, pid, null, null, null);
+
+            fileHashStore.getHexDigest(pid, "BLAKE2S");
+        }
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -944,7 +944,7 @@ public class FileHashStoreInterfaceTest {
             // Double check that file doesn't exist
             assertFalse(Files.exists(objInfo.getAbsPath()));
 
-            // Double check that store root still exists
+            // Double check that object directory still exists
             Path storePath = (Path) this.fhsProperties.get("storePath");
             Path storeObjectPath = storePath.resolve("objects");
             assertTrue(Files.exists(storeObjectPath));
@@ -952,7 +952,7 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Confirm that deleteObject deletes object and empty sub directories
+     * Confirm that deleteObject throws exception when associated pid obj not found
      */
     @Test(expected = FileNotFoundException.class)
     public void deleteObject_pidNotFound() throws Exception {
@@ -960,7 +960,7 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Confirm that deleteObject deletes object and empty sub directories
+     * Confirm that deleteObject throws exception when pid is null
      */
     @Test(expected = IllegalArgumentException.class)
     public void deleteObject_pidNull() throws Exception {
@@ -968,7 +968,7 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Confirm that deleteObject deletes object and empty sub directories
+     * Confirm that deleteObject throws exception when pid is empty
      */
     @Test(expected = IllegalArgumentException.class)
     public void deleteObject_pidEmpty() throws Exception {
@@ -976,10 +976,108 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Confirm that deleteObject deletes object and empty sub directories
+     * Confirm that deleteObject throws exception when pid is empty spaces
      */
     @Test(expected = IllegalArgumentException.class)
     public void deleteObject_pidEmptySpaces() throws Exception {
         fileHashStore.deleteObject("      ");
+    }
+
+    /**
+     * Confirm that deleteMetadata deletes object and empty sub directories
+     */
+    @Test
+    public void deleteMetadata() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test metadata file
+            Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
+
+            InputStream metadataStream = Files.newInputStream(testMetaDataFile);
+            String metadataCid = fileHashStore.storeMetadata(metadataStream, pid, null);
+
+            String storeFormatId = (String) this.fhsProperties.get("storeMetadataNamespace");
+            boolean isMetadataDeleted = fileHashStore.deleteMetadata(pid, storeFormatId);
+            assertTrue(isMetadataDeleted);
+
+            // Double check that file doesn't exist
+            Path storePath = (Path) this.fhsProperties.get("storePath");
+            Path metadataStoreDirectory = storePath.resolve("metadata");
+            int storeDepth = (int) this.fhsProperties.get("storeDepth");
+            int storeWidth = (int) this.fhsProperties.get("storeWidth");
+            String metadataCidShardString = fileHashStore.getHierarchicalPathString(storeDepth, storeWidth,
+                    metadataCid);
+            Path metadataCidPath = metadataStoreDirectory.resolve(metadataCidShardString);
+            assertFalse(Files.exists(metadataCidPath));
+
+            // Double check that metadata directory still exists
+            Path storeObjectPath = storePath.resolve("metadata");
+            assertTrue(Files.exists(storeObjectPath));
+        }
+    }
+
+    /**
+     * Confirm that deleteMetadata throws exception when associated pid obj not
+     * found
+     */
+    @Test(expected = FileNotFoundException.class)
+    public void deleteMetadata_pidNotFound() throws Exception {
+        String formatId = "http://hashstore.tests/types/v1.0";
+        fileHashStore.deleteMetadata("dou.2023.hashstore.1", formatId);
+    }
+
+    /**
+     * Confirm that deleteMetadata throws exception when pid is null
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteMetadata_pidNull() throws Exception {
+        String formatId = "http://hashstore.tests/types/v1.0";
+        fileHashStore.deleteMetadata(null, formatId);
+    }
+
+    /**
+     * Confirm that deleteMetadata throws exception when pid is empty
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteMetadata_pidEmpty() throws Exception {
+        String formatId = "http://hashstore.tests/types/v1.0";
+        fileHashStore.deleteMetadata("", formatId);
+    }
+
+    /**
+     * Confirm that deleteMetadata throws exception when pid is empty spaces
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteMetadata_pidEmptySpaces() throws Exception {
+        String formatId = "http://hashstore.tests/types/v1.0";
+        fileHashStore.deleteMetadata("      ", formatId);
+    }
+
+    /**
+     * Confirm that deleteMetadata throws exception when formatId is null
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteMetadata_formatIdNull() throws Exception {
+        String pid = "dou.2023.hashstore.1";
+        fileHashStore.deleteMetadata(pid, null);
+    }
+
+    /**
+     * Confirm that deleteMetadata throws exception when formatId is empty
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteMetadata_formatIdEmpty() throws Exception {
+        String pid = "dou.2023.hashstore.1";
+        fileHashStore.deleteMetadata(pid, "");
+    }
+
+    /**
+     * Confirm that deleteMetadata throws exception when formatId is empty spaces
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteMetadata_formatIdEmptySpaces() throws Exception {
+        String pid = "dou.2023.hashstore.1";
+        fileHashStore.deleteMetadata(pid, "     ");
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -116,8 +116,8 @@ public class FileHashStoreInterfaceTest {
             HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
 
             // Check absolute path
-            File objAbsPath = new File(objInfo.getAbsPath());
-            assertTrue(objAbsPath.exists());
+            Path objAbsPath = objInfo.getAbsPath();
+            assertTrue(Files.exists(objAbsPath));
         }
     }
 
@@ -219,8 +219,8 @@ public class FileHashStoreInterfaceTest {
         InputStream dataStream = Files.newInputStream(testDataFile);
         HashAddress address = fileHashStore.storeObject(dataStream, pid, null, checksumCorrect, "SHA-256");
 
-        File objAbsPath = new File(address.getAbsPath());
-        assertTrue(objAbsPath.exists());
+        Path objAbsPath = address.getAbsPath();
+        assertTrue(Files.exists(objAbsPath));
     }
 
     /**
@@ -348,9 +348,8 @@ public class FileHashStoreInterfaceTest {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
                 if (objInfo != null) {
-                    String absPath = objInfo.getAbsPath();
-                    File permAddress = new File(absPath);
-                    assertTrue(permAddress.exists());
+                    Path absPath = objInfo.getAbsPath();
+                    assertTrue(Files.exists(absPath));
                 }
             } catch (Exception e) {
                 System.out.println(e.getClass());
@@ -363,9 +362,8 @@ public class FileHashStoreInterfaceTest {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
                 if (objInfo != null) {
-                    String absPath = objInfo.getAbsPath();
-                    File permAddress = new File(absPath);
-                    assertTrue(permAddress.exists());
+                    Path absPath = objInfo.getAbsPath();
+                    assertTrue(Files.exists(absPath));
                 }
             } catch (Exception e) {
                 System.out.println(e.getClass());
@@ -378,9 +376,8 @@ public class FileHashStoreInterfaceTest {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
                 if (objInfo != null) {
-                    String absPath = objInfo.getAbsPath();
-                    File permAddress = new File(absPath);
-                    assertTrue(permAddress.exists());
+                    Path absPath = objInfo.getAbsPath();
+                    assertTrue(Files.exists(absPath));
                 }
             } catch (Exception e) {
                 System.out.println(e.getClass());
@@ -393,9 +390,8 @@ public class FileHashStoreInterfaceTest {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
                 if (objInfo != null) {
-                    String absPath = objInfo.getAbsPath();
-                    File permAddress = new File(absPath);
-                    assertTrue(permAddress.exists());
+                    Path absPath = objInfo.getAbsPath();
+                    assertTrue(Files.exists(absPath));
                 }
             } catch (Exception e) {
                 System.out.println(e.getClass());
@@ -408,9 +404,8 @@ public class FileHashStoreInterfaceTest {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
                 if (objInfo != null) {
-                    String absPath = objInfo.getAbsPath();
-                    File permAddress = new File(absPath);
-                    assertTrue(permAddress.exists());
+                    Path absPath = objInfo.getAbsPath();
+                    assertTrue(Files.exists(absPath));
                 }
             } catch (Exception e) {
                 System.out.println(e.getClass());
@@ -452,9 +447,8 @@ public class FileHashStoreInterfaceTest {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
                 if (objInfo != null) {
-                    String absPath = objInfo.getAbsPath();
-                    File permAddress = new File(absPath);
-                    assertTrue(permAddress.exists());
+                    Path absPath = objInfo.getAbsPath();
+                    assertTrue(Files.exists(absPath));
                 }
             } catch (Exception e) {
                 System.out.println(e.getClass());
@@ -467,9 +461,8 @@ public class FileHashStoreInterfaceTest {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
                 if (objInfo != null) {
-                    String absPath = objInfo.getAbsPath();
-                    File permAddress = new File(absPath);
-                    assertTrue(permAddress.exists());
+                    Path absPath = objInfo.getAbsPath();
+                    assertTrue(Files.exists(absPath));
                 }
             } catch (Exception e) {
                 System.out.println(e.getClass());
@@ -932,5 +925,62 @@ public class FileHashStoreInterfaceTest {
             // Close stream
             metadataCidInputStream.close();
         }
+    }
+
+    /**
+     * Confirm that deleteObject deletes object and empty sub directories
+     */
+    @Test
+    public void deleteObject() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+
+            boolean isFileDeleted = fileHashStore.deleteObject(pid);
+            assertTrue(isFileDeleted);
+
+            // Double check that file doesn't exist
+            assertFalse(Files.exists(objInfo.getAbsPath()));
+
+            // Double check that store root still exists
+            Path storePath = (Path) this.fhsProperties.get("storePath");
+            Path storeObjectPath = storePath.resolve("objects");
+            assertTrue(Files.exists(storeObjectPath));
+        }
+    }
+
+    /**
+     * Confirm that deleteObject deletes object and empty sub directories
+     */
+    @Test(expected = FileNotFoundException.class)
+    public void deleteObject_pidNotFound() throws Exception {
+        fileHashStore.deleteObject("dou.2023.hashstore.1");
+    }
+
+    /**
+     * Confirm that deleteObject deletes object and empty sub directories
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteObject_pidNull() throws Exception {
+        fileHashStore.deleteObject(null);
+    }
+
+    /**
+     * Confirm that deleteObject deletes object and empty sub directories
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteObject_pidEmpty() throws Exception {
+        fileHashStore.deleteObject("");
+    }
+
+    /**
+     * Confirm that deleteObject deletes object and empty sub directories
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteObject_pidEmptySpaces() throws Exception {
+        fileHashStore.deleteObject("      ");
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -223,8 +223,8 @@ public class FileHashStoreProtectedTest {
             HashAddress address = fileHashStore.putObject(dataStream, pid, null, null, null);
 
             // Check absolute path
-            File objAbsPath = new File(address.getAbsPath());
-            assertTrue(objAbsPath.exists());
+            Path absPath = address.getAbsPath();
+            assertTrue(Files.exists(absPath));
         }
     }
 
@@ -289,8 +289,8 @@ public class FileHashStoreProtectedTest {
         InputStream dataStream = Files.newInputStream(testDataFile);
         HashAddress address = fileHashStore.putObject(dataStream, pid, null, checksumCorrect, "MD2");
 
-        File objAbsPath = new File(address.getAbsPath());
-        assertTrue(objAbsPath.exists());
+        Path absPath = address.getAbsPath();
+        assertTrue(Files.exists(absPath));
     }
 
     /**


### PR DESCRIPTION
Summary of Changes:
- Add public API methods `deleteObject`, `deleteMetadata` and `getHexDigest` plus new junit tests
- Refactor `HashAddress` absPath member to be Path object instead of String, added `final` access modifier to all members, and updated all affected junit tests