### PR TITLE
Feature-41: Refactor Hashaddress & Overload Methods

### DIFF
--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -38,7 +38,7 @@ public interface HashStore {
          * with its corresponding hex digest. An algorithm is considered "supported" if it is
          * recognized as a valid hash algorithm in the `java.security.MessageDigest` class.
          * 
-         * Similarly, if a checksum and a checksumAlgorithm or an object size value are provided,
+         * Similarly, if a checksum and a checksumAlgorithm or an object size value is provided,
          * `storeObject` validates the object to ensure it matches what is provided before moving
          * the file to its permanent address.
          * 

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -18,7 +18,8 @@ public interface HashStore {
         /**
          * The `storeObject` method is responsible for the atomic storage of objects to HashStore
          * using a given InputStream and a persistent identifier (pid). Upon successful storage, the
-         * method returns a (HashAddress) object containing the object's file information, such as
+         * method returns a (ObjectMetadata) object containing the object's file information, such
+         * as
          * the id, relative path, duplicate object status, and hex digest map of algorithms and hex
          * digests/checksums. An object is stored once and only once - and `storeObject` also
          * enforces this rule by synchronizing multiple calls and rejecting calls to store duplicate
@@ -46,7 +47,7 @@ public interface HashStore {
          * @param additionalAlgorithm Additional hex digest to include in hexDigests
          * @param checksum            Value of checksum to validate against
          * @param checksumAlgorithm   Algorithm of checksum submitted
-         * @return HashAddress object encapsulating file information
+         * @return ObjectMetadata object encapsulating file information
          * @throws NoSuchAlgorithmException When additionalAlgorithm or checksumAlgorithm is invalid
          * @throws IOException              I/O Error when writing file, generating checksums and/or
          *                                  moving file
@@ -54,7 +55,7 @@ public interface HashStore {
          * @throws RuntimeException         Thrown when there is an issue with permissions, illegal
          *                                  arguments (ex. empty pid) or null pointers
          */
-        HashAddress storeObject(
+        ObjectMetadata storeObject(
                 InputStream object, String pid, String additionalAlgorithm, String checksum,
                 String checksumAlgorithm
         ) throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException;

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -38,15 +38,16 @@ public interface HashStore {
          * with its corresponding hex digest. An algorithm is considered "supported" if it is
          * recognized as a valid hash algorithm in the `java.security.MessageDigest` class.
          * 
-         * Similarly, if a checksum and a checksumAlgorithm value are provided, `storeObject`
-         * validates the object to ensure it matches what is provided before moving the file to its
-         * permanent address.
+         * Similarly, if a checksum and a checksumAlgorithm or an object size value are provided,
+         * `storeObject` validates the object to ensure it matches what is provided before moving
+         * the file to its permanent address.
          * 
          * @param object              Input stream to file
          * @param pid                 Authority-based identifier
          * @param additionalAlgorithm Additional hex digest to include in hexDigests
          * @param checksum            Value of checksum to validate against
          * @param checksumAlgorithm   Algorithm of checksum submitted
+         * @param objSize             Expected size of object to validate after storing
          * @return ObjectMetadata object encapsulating file information
          * @throws NoSuchAlgorithmException When additionalAlgorithm or checksumAlgorithm is invalid
          * @throws IOException              I/O Error when writing file, generating checksums and/or
@@ -57,7 +58,7 @@ public interface HashStore {
          */
         ObjectMetadata storeObject(
                 InputStream object, String pid, String additionalAlgorithm, String checksum,
-                String checksumAlgorithm
+                String checksumAlgorithm, long objSize
         ) throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException;
 
         /**

--- a/src/main/java/org/dataone/hashstore/ObjectMetadata.java
+++ b/src/main/java/org/dataone/hashstore/ObjectMetadata.java
@@ -3,13 +3,14 @@ package org.dataone.hashstore;
 import java.util.Map;
 
 /**
- * ObjectMetadata is a class that models a unique identifier for a file in the Hashstore. It
- * encapsulates information about the file's name, path, and associated hash digest values. By using
+ * ObjectMetadata is a class that models a unique identifier for an object in the Hashstore. It
+ * encapsulates information about a file's name, path, and associated hash digest values. By using
  * ObjectMetadata objects, client code can easily obtain metadata of a store object in HashStore
  * without needing to know the underlying file system details.
  */
 public class ObjectMetadata {
     private final String id;
+    private final long size;
     private final boolean isDuplicate;
     private final Map<String, String> hexDigests;
 
@@ -21,10 +22,13 @@ public class ObjectMetadata {
      * @param hexDigests  A map of hash algorithm names to their hex-encoded digest values for the
      *                    file
      */
-    public ObjectMetadata(String id, boolean isDuplicate, Map<String, String> hexDigests) {
+    public ObjectMetadata(
+        String id, long size, boolean isDuplicate, Map<String, String> hexDigests
+    ) {
         this.id = id;
         this.isDuplicate = isDuplicate;
         this.hexDigests = hexDigests;
+        this.size = size;
     }
 
     /**
@@ -37,6 +41,15 @@ public class ObjectMetadata {
     }
 
     /**
+     * Return the size of the file
+     * 
+     * @return id
+     */
+    public long getSize() {
+        return size;
+    }
+
+    /**
      * Return the flag of whether a file is a duplicate or not
      * 
      * @return True if the file is not a duplicate, false otherwise
@@ -44,6 +57,7 @@ public class ObjectMetadata {
     public boolean getIsDuplicate() {
         return isDuplicate;
     }
+
 
     /**
      * Return a map of hex digests

--- a/src/main/java/org/dataone/hashstore/ObjectMetadata.java
+++ b/src/main/java/org/dataone/hashstore/ObjectMetadata.java
@@ -3,25 +3,25 @@ package org.dataone.hashstore;
 import java.util.Map;
 
 /**
- * HashAddress is a class that models a unique identifier for a file in the Hashstore. It
+ * ObjectMetadata is a class that models a unique identifier for a file in the Hashstore. It
  * encapsulates information about the file's name, path, and associated hash digest values. By using
- * HashAddress objects, client code can easily locate, retrieve, and modify files in the HashStore
+ * ObjectMetadata objects, client code can easily obtain metadata of a store object in HashStore
  * without needing to know the underlying file system details.
  */
-public class HashAddress {
+public class ObjectMetadata {
     private final String id;
     private final boolean isDuplicate;
     private final Map<String, String> hexDigests;
 
     /**
-     * Creates a new instance of HashAddress with the given properties.
+     * Creates a new instance of ObjectMetadata with the given properties.
      *
      * @param id          Unique identifier for the file
      * @param isDuplicate Flag indicating if the file is a duplicate of an existing file
      * @param hexDigests  A map of hash algorithm names to their hex-encoded digest values for the
      *                    file
      */
-    public HashAddress(String id, boolean isDuplicate, Map<String, String> hexDigests) {
+    public ObjectMetadata(String id, boolean isDuplicate, Map<String, String> hexDigests) {
         this.id = id;
         this.isDuplicate = isDuplicate;
         this.hexDigests = hexDigests;

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -277,12 +277,22 @@ public class FileHashStore implements HashStore {
         try {
             HashMap<?, ?> hashStoreYamlProperties = om.readValue(hashStoreYaml, HashMap.class);
             String yamlStorePath = (String) hashStoreYamlProperties.get("store_path");
-            hsProperties.put("storePath", Paths.get(yamlStorePath));
-            hsProperties.put("storeDepth", hashStoreYamlProperties.get("store_depth"));
-            hsProperties.put("storeWidth", hashStoreYamlProperties.get("store_width"));
-            hsProperties.put("storeAlgorithm", hashStoreYamlProperties.get("store_algorithm"));
+            hsProperties.put(HashStoreProperties.storePath.name(), Paths.get(yamlStorePath));
             hsProperties.put(
-                "storeMetadataNamespace", hashStoreYamlProperties.get("store_metadata_namespace")
+                HashStoreProperties.storeDepth.name(), hashStoreYamlProperties.get("store_depth")
+            );
+            hsProperties.put(
+                HashStoreProperties.storeWidth.name(), hashStoreYamlProperties.get("store_width")
+            );
+            hsProperties.put(
+                HashStoreProperties.storeAlgorithm.name(), hashStoreYamlProperties.get(
+                    "store_algorithm"
+                )
+            );
+            hsProperties.put(
+                HashStoreProperties.storeMetadataNamespace.name(), hashStoreYamlProperties.get(
+                    "store_metadata_namespace"
+                )
             );
 
         } catch (IOException ioe) {

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -819,6 +819,7 @@ public class FileHashStore implements HashStore {
         Map<String, String> hexDigests = writeToTmpFileAndGenerateChecksums(
             tmpFile, object, additionalAlgorithm, checksumAlgorithm
         );
+        long tmpFileSize = 0;
 
         // Validate object if checksum and checksum algorithm is passed
         validateTmpObject(requestValidation, checksum, checksumAlgorithm, tmpFile, hexDigests);
@@ -855,7 +856,7 @@ public class FileHashStore implements HashStore {
         }
 
         // Create ObjectMetadata to return with pertinent data
-        return new ObjectMetadata(objectCid, isDuplicate, hexDigests);
+        return new ObjectMetadata(objectCid, tmpFileSize, isDuplicate, hexDigests);
     }
 
     /**

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -414,7 +414,7 @@ public class FileHashStore implements HashStore {
             isStringEmpty(checksumAlgorithm, "checksumAlgorithm", "storeObject");
             validateAlgorithm(checksumAlgorithm);
         }
-        isObjectLessThanOrEqualToZero(objSize, "objSize", "storeObject");
+        isObjectLessThanZero(objSize, "objSize", "storeObject");
 
         // Lock pid for thread safety, transaction control and atomic writing
         // A pid can only be stored once and only once, subsequent calls will
@@ -796,7 +796,7 @@ public class FileHashStore implements HashStore {
             isStringEmpty(checksumAlgorithm, "checksumAlgorithm", "putObject");
             validateAlgorithm(checksumAlgorithm);
         }
-        isObjectLessThanOrEqualToZero(objSize, "objSize", "putObject");
+        isObjectLessThanZero(objSize, "objSize", "putObject");
 
         // If validation is desired, checksumAlgorithm and checksum must both be present
         boolean requestValidation = verifyChecksumParameters(checksum, checksumAlgorithm);
@@ -1491,7 +1491,7 @@ public class FileHashStore implements HashStore {
      * @param argument Value that is being checked
      * @param method   Calling method
      */
-    private void isObjectLessThanOrEqualToZero(long object, String argument, String method) {
+    private void isObjectLessThanZero(long object, String argument, String method) {
         if (object < 0) {
             String errMsg = "FileHashStore.isObjectGreaterThanZero - Calling Method: " + method
                 + "(): " + argument + " cannot be less than 0.";

--- a/src/test/java/org/dataone/hashstore/HashStoreTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreTest.java
@@ -119,7 +119,7 @@ public class HashStoreTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = hashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = hashStore.storeObject(dataStream, pid, null, null, null, 0);
 
             // Check id (sha-256 hex digest of the ab_id, aka object_cid)
             String objAuthorityId = testData.pidData.get(pid).get("object_cid");

--- a/src/test/java/org/dataone/hashstore/HashStoreTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreTest.java
@@ -119,7 +119,7 @@ public class HashStoreTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress objInfo = hashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = hashStore.storeObject(dataStream, pid, null, null, null);
 
             // Check id (sha-256 hex digest of the ab_id, aka object_cid)
             String objAuthorityId = testData.pidData.get(pid).get("object_cid");

--- a/src/test/java/org/dataone/hashstore/ObjectMetadataTest.java
+++ b/src/test/java/org/dataone/hashstore/ObjectMetadataTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 public class ObjectMetadataTest {
     private static String id = "";
     private static boolean isDuplicate;
+    private static long size;
     private static Map<String, String> hexDigests;
 
     /**
@@ -24,6 +25,7 @@ public class ObjectMetadataTest {
     public static void initializeInstanceVariables() {
         id = "94f9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a";
         isDuplicate = true;
+        size = 1999999;
         hexDigests = new HashMap<>();
         hexDigests.put("md5", "f4ea2d07db950873462a064937197b0f");
         hexDigests.put("sha1", "3d25436c4490b08a2646e283dada5c60e5c0539d");
@@ -45,7 +47,7 @@ public class ObjectMetadataTest {
      */
     @Test
     public void testHashAddress() {
-        ObjectMetadata hashad = new ObjectMetadata(id, isDuplicate, hexDigests);
+        ObjectMetadata hashad = new ObjectMetadata(id, size, isDuplicate, hexDigests);
         assertNotNull(hashad);
     }
 
@@ -54,9 +56,19 @@ public class ObjectMetadataTest {
      */
     @Test
     public void testHashAddressGetId() {
-        ObjectMetadata hashad = new ObjectMetadata(id, isDuplicate, hexDigests);
+        ObjectMetadata hashad = new ObjectMetadata(id, size, isDuplicate, hexDigests);
         String hashad_id = hashad.getId();
         assertEquals(hashad_id, id);
+    }
+
+    /**
+     * Check ObjectMetadata get size
+     */
+    @Test
+    public void testHashAddressGetSize() {
+        ObjectMetadata hashad = new ObjectMetadata(id, size, isDuplicate, hexDigests);
+        long hashad_size = hashad.getSize();
+        assertEquals(hashad_size, size);
     }
 
     /**
@@ -64,7 +76,7 @@ public class ObjectMetadataTest {
      */
     @Test
     public void testHashAddressGetIsDuplicate() {
-        ObjectMetadata hashad = new ObjectMetadata(id, isDuplicate, hexDigests);
+        ObjectMetadata hashad = new ObjectMetadata(id, size, isDuplicate, hexDigests);
         boolean hashad_isDuplicate = hashad.getIsDuplicate();
         assertEquals(hashad_isDuplicate, isDuplicate);
     }
@@ -74,7 +86,7 @@ public class ObjectMetadataTest {
      */
     @Test
     public void testHashAddressGetHexDigests() {
-        ObjectMetadata hashad = new ObjectMetadata(id, isDuplicate, hexDigests);
+        ObjectMetadata hashad = new ObjectMetadata(id, size, isDuplicate, hexDigests);
         Map<String, String> hashad_map = hashad.getHexDigests();
         assertEquals(hashad_map, hexDigests);
     }

--- a/src/test/java/org/dataone/hashstore/ObjectMetadataTest.java
+++ b/src/test/java/org/dataone/hashstore/ObjectMetadataTest.java
@@ -10,15 +10,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test class for HashAddress
+ * Test class for ObjectMetadata
  */
-public class HashAddressTest {
+public class ObjectMetadataTest {
     private static String id = "";
     private static boolean isDuplicate;
     private static Map<String, String> hexDigests;
 
     /**
-     * Initialize HashAddress variables for test efficiency purposes
+     * Initialize ObjectMetadata variables for test efficiency purposes
      */
     @BeforeClass
     public static void initializeInstanceVariables() {
@@ -41,40 +41,40 @@ public class HashAddressTest {
     }
 
     /**
-     * Check HashAddress constructor
+     * Check ObjectMetadata constructor
      */
     @Test
     public void testHashAddress() {
-        HashAddress hashad = new HashAddress(id, isDuplicate, hexDigests);
+        ObjectMetadata hashad = new ObjectMetadata(id, isDuplicate, hexDigests);
         assertNotNull(hashad);
     }
 
     /**
-     * Check HashAddress get id
+     * Check ObjectMetadata get id
      */
     @Test
     public void testHashAddressGetId() {
-        HashAddress hashad = new HashAddress(id, isDuplicate, hexDigests);
+        ObjectMetadata hashad = new ObjectMetadata(id, isDuplicate, hexDigests);
         String hashad_id = hashad.getId();
         assertEquals(hashad_id, id);
     }
 
     /**
-     * Check HashAddress get isDuplicate
+     * Check ObjectMetadata get isDuplicate
      */
     @Test
     public void testHashAddressGetIsDuplicate() {
-        HashAddress hashad = new HashAddress(id, isDuplicate, hexDigests);
+        ObjectMetadata hashad = new ObjectMetadata(id, isDuplicate, hexDigests);
         boolean hashad_isDuplicate = hashad.getIsDuplicate();
         assertEquals(hashad_isDuplicate, isDuplicate);
     }
 
     /**
-     * Check HashAddress get hexDigests
+     * Check ObjectMetadata get hexDigests
      */
     @Test
     public void testHashAddressGetHexDigests() {
-        HashAddress hashad = new HashAddress(id, isDuplicate, hexDigests);
+        ObjectMetadata hashad = new ObjectMetadata(id, isDuplicate, hexDigests);
         Map<String, String> hashad_map = hashad.getHexDigests();
         assertEquals(hashad_map, hexDigests);
     }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 
 import javax.xml.bind.DatatypeConverter;
 
-import org.dataone.hashstore.HashAddress;
+import org.dataone.hashstore.ObjectMetadata;
 import org.dataone.hashstore.exceptions.PidObjectExistsException;
 import org.dataone.hashstore.testdata.TestDataHarness;
 import org.junit.Before;
@@ -91,7 +91,7 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Check that store object returns the correct HashAddress object id
+     * Check that store object returns the correct ObjectMetadata id
      */
     @Test
     public void storeObject() throws Exception {
@@ -100,7 +100,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
 
             // Check id (sha-256 hex digest of the ab_id (pid))
             String objectCid = testData.pidData.get(pid).get("object_cid");
@@ -118,7 +118,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
 
             // Check duplicate status
             assertFalse(objInfo.getIsDuplicate());
@@ -126,7 +126,7 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Check that store object returns the correct HashAddress object hex digests
+     * Check that store object returns the correct ObjectMetadata hex digests
      */
     @Test
     public void storeObject_hexDigests() throws Exception {
@@ -135,7 +135,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
 
             Map<String, String> hexDigests = objInfo.getHexDigests();
 
@@ -202,7 +202,7 @@ public class FileHashStoreInterfaceTest {
         String checksumCorrect = "94f9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a";
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        HashAddress address = fileHashStore.storeObject(
+        ObjectMetadata address = fileHashStore.storeObject(
             dataStream, pid, null, checksumCorrect, "SHA-256"
         );
 
@@ -329,7 +329,7 @@ public class FileHashStoreInterfaceTest {
 
         InputStream dataStream = Files.newInputStream(testFilePath);
         String pid = "dou.sparsefile.1";
-        HashAddress sparseFileObjInfo = fileHashStore.storeObject(
+        ObjectMetadata sparseFileObjInfo = fileHashStore.storeObject(
             dataStream, pid, null, null, null
         );
 
@@ -367,7 +367,9 @@ public class FileHashStoreInterfaceTest {
         Future<?> future1 = executorService.submit(() -> {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
-                HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+                ObjectMetadata objInfo = fileHashStore.storeObject(
+                    dataStream, pid, null, null, null
+                );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
                     Path objCidAbsPath = getObjectAbsPath(objId);
@@ -382,7 +384,9 @@ public class FileHashStoreInterfaceTest {
         Future<?> future2 = executorService.submit(() -> {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
-                HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+                ObjectMetadata objInfo = fileHashStore.storeObject(
+                    dataStream, pid, null, null, null
+                );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
                     Path objCidAbsPath = getObjectAbsPath(objId);
@@ -397,7 +401,9 @@ public class FileHashStoreInterfaceTest {
         Future<?> future3 = executorService.submit(() -> {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
-                HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+                ObjectMetadata objInfo = fileHashStore.storeObject(
+                    dataStream, pid, null, null, null
+                );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
                     Path objCidAbsPath = getObjectAbsPath(objId);
@@ -412,7 +418,9 @@ public class FileHashStoreInterfaceTest {
         Future<?> future4 = executorService.submit(() -> {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
-                HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+                ObjectMetadata objInfo = fileHashStore.storeObject(
+                    dataStream, pid, null, null, null
+                );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
                     Path objCidAbsPath = getObjectAbsPath(objId);
@@ -427,7 +435,9 @@ public class FileHashStoreInterfaceTest {
         Future<?> future5 = executorService.submit(() -> {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
-                HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+                ObjectMetadata objInfo = fileHashStore.storeObject(
+                    dataStream, pid, null, null, null
+                );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
                     Path objCidAbsPath = getObjectAbsPath(objId);
@@ -470,7 +480,9 @@ public class FileHashStoreInterfaceTest {
         Future<?> future1 = executorService.submit(() -> {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
-                HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+                ObjectMetadata objInfo = fileHashStore.storeObject(
+                    dataStream, pid, null, null, null
+                );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
                     Path objCidAbsPath = getObjectAbsPath(objId);
@@ -485,7 +497,9 @@ public class FileHashStoreInterfaceTest {
         Future<?> future2 = executorService.submit(() -> {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
-                HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+                ObjectMetadata objInfo = fileHashStore.storeObject(
+                    dataStream, pid, null, null, null
+                );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
                     Path objCidAbsPath = getObjectAbsPath(objId);
@@ -963,7 +977,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
 
             boolean isFileDeleted = fileHashStore.deleteObject(pid);
             assertTrue(isFileDeleted);
@@ -1115,7 +1129,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
 
             // Then get the checksum
             String pidHexDigest = fileHashStore.getHexDigest(pid, "SHA-256");

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -100,7 +100,9 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, 0
+            );
 
             // Check id (sha-256 hex digest of the ab_id (pid))
             String objectCid = testData.pidData.get(pid).get("object_cid");
@@ -118,7 +120,9 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, 0
+            );
 
             // Check duplicate status
             assertFalse(objInfo.getIsDuplicate());
@@ -135,7 +139,9 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, 0
+            );
 
             Map<String, String> hexDigests = objInfo.getHexDigests();
 
@@ -159,7 +165,7 @@ public class FileHashStoreInterfaceTest {
     @Test(expected = NullPointerException.class)
     public void storeObject_null() throws Exception {
         String pid = "j.tao.1700.1";
-        fileHashStore.storeObject(null, pid, null, null, null);
+        fileHashStore.storeObject(null, pid, null, null, null, 0);
     }
 
     /**
@@ -172,7 +178,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            fileHashStore.storeObject(dataStream, null, null, null, null);
+            fileHashStore.storeObject(dataStream, null, null, null, null, 0);
         }
     }
 
@@ -186,7 +192,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            fileHashStore.storeObject(dataStream, "", null, null, null);
+            fileHashStore.storeObject(dataStream, "", null, null, null, 0);
         }
     }
 
@@ -203,7 +209,7 @@ public class FileHashStoreInterfaceTest {
 
         InputStream dataStream = Files.newInputStream(testDataFile);
         ObjectMetadata address = fileHashStore.storeObject(
-            dataStream, pid, null, checksumCorrect, "SHA-256"
+            dataStream, pid, null, checksumCorrect, "SHA-256", 0
         );
 
         String objCid = address.getId();
@@ -223,7 +229,7 @@ public class FileHashStoreInterfaceTest {
         String checksumCorrect = "9c25df1c8ba1d2e57bb3fd4785878b85";
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.storeObject(dataStream, pid, "MD2", null, null);
+        fileHashStore.storeObject(dataStream, pid, "MD2", null, null, 0);
 
         String md2 = testData.pidData.get(pid).get("md2");
         assertEquals(checksumCorrect, md2);
@@ -242,7 +248,7 @@ public class FileHashStoreInterfaceTest {
             "aaf9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a";
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.storeObject(dataStream, pid, null, checksumIncorrect, "SHA-256");
+        fileHashStore.storeObject(dataStream, pid, null, checksumIncorrect, "SHA-256", 0);
     }
 
     /**
@@ -257,7 +263,7 @@ public class FileHashStoreInterfaceTest {
         String checksumEmpty = "";
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.storeObject(dataStream, pid, null, checksumEmpty, "MD2");
+        fileHashStore.storeObject(dataStream, pid, null, checksumEmpty, "MD2", 0);
     }
 
     /**
@@ -270,7 +276,7 @@ public class FileHashStoreInterfaceTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.storeObject(dataStream, pid, null, null, "SHA-512/224");
+        fileHashStore.storeObject(dataStream, pid, null, null, "SHA-512/224", 0);
     }
 
     /**
@@ -283,7 +289,7 @@ public class FileHashStoreInterfaceTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.storeObject(dataStream, pid, "SM2", null, null);
+        fileHashStore.storeObject(dataStream, pid, "SM2", null, null, 0);
     }
 
     /**
@@ -296,10 +302,10 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            fileHashStore.storeObject(dataStream, pid, null, null, null);
+            fileHashStore.storeObject(dataStream, pid, null, null, null, 0);
 
             InputStream dataStreamDup = Files.newInputStream(testDataFile);
-            fileHashStore.storeObject(dataStreamDup, pid, null, null, null);
+            fileHashStore.storeObject(dataStreamDup, pid, null, null, null, 0);
         }
     }
 
@@ -330,7 +336,7 @@ public class FileHashStoreInterfaceTest {
         InputStream dataStream = Files.newInputStream(testFilePath);
         String pid = "dou.sparsefile.1";
         ObjectMetadata sparseFileObjInfo = fileHashStore.storeObject(
-            dataStream, pid, null, null, null
+            dataStream, pid, null, null, null, 0
         );
 
         String objCid = sparseFileObjInfo.getId();
@@ -368,7 +374,7 @@ public class FileHashStoreInterfaceTest {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 ObjectMetadata objInfo = fileHashStore.storeObject(
-                    dataStream, pid, null, null, null
+                    dataStream, pid, null, null, null, 0
                 );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
@@ -385,7 +391,7 @@ public class FileHashStoreInterfaceTest {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 ObjectMetadata objInfo = fileHashStore.storeObject(
-                    dataStream, pid, null, null, null
+                    dataStream, pid, null, null, null, 0
                 );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
@@ -402,7 +408,7 @@ public class FileHashStoreInterfaceTest {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 ObjectMetadata objInfo = fileHashStore.storeObject(
-                    dataStream, pid, null, null, null
+                    dataStream, pid, null, null, null, 0
                 );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
@@ -419,7 +425,7 @@ public class FileHashStoreInterfaceTest {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 ObjectMetadata objInfo = fileHashStore.storeObject(
-                    dataStream, pid, null, null, null
+                    dataStream, pid, null, null, null, 0
                 );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
@@ -436,7 +442,7 @@ public class FileHashStoreInterfaceTest {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 ObjectMetadata objInfo = fileHashStore.storeObject(
-                    dataStream, pid, null, null, null
+                    dataStream, pid, null, null, null, 0
                 );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
@@ -481,7 +487,7 @@ public class FileHashStoreInterfaceTest {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 ObjectMetadata objInfo = fileHashStore.storeObject(
-                    dataStream, pid, null, null, null
+                    dataStream, pid, null, null, null, 0
                 );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
@@ -498,7 +504,7 @@ public class FileHashStoreInterfaceTest {
             try {
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 ObjectMetadata objInfo = fileHashStore.storeObject(
-                    dataStream, pid, null, null, null
+                    dataStream, pid, null, null, null, 0
                 );
                 if (objInfo != null) {
                     String objId = objInfo.getId();
@@ -725,7 +731,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            fileHashStore.storeObject(dataStream, pid, null, null, null);
+            fileHashStore.storeObject(dataStream, pid, null, null, null, 0);
 
             // Retrieve object
             InputStream objectCidInputStream = fileHashStore.retrieveObject(pid);
@@ -779,7 +785,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            fileHashStore.storeObject(dataStream, pid, null, null, null);
+            fileHashStore.storeObject(dataStream, pid, null, null, null, 0);
 
             // Retrieve object
             InputStream objectCidInputStream;
@@ -977,7 +983,9 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, 0
+            );
 
             boolean isFileDeleted = fileHashStore.deleteObject(pid);
             assertTrue(isFileDeleted);
@@ -1129,7 +1137,9 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, 0
+            );
 
             // Then get the checksum
             String pidHexDigest = fileHashStore.getHexDigest(pid, "SHA-256");
@@ -1186,7 +1196,7 @@ public class FileHashStoreInterfaceTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            fileHashStore.storeObject(dataStream, pid, null, null, null);
+            fileHashStore.storeObject(dataStream, pid, null, null, null, 0);
 
             fileHashStore.getHexDigest(pid, "BLAKE2S");
         }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -111,6 +111,26 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
+     * Check that store object returns the correct ObjectMetadata size
+     */
+    @Test
+    public void storeObject_objSize() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, 0
+            );
+
+            // Check id (sha-256 hex digest of the ab_id (pid))
+            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
+            assertEquals(objectSize, objInfo.getSize());
+        }
+    }
+
+    /**
      * Check that store object moves file successfully (isDuplicate == false)
      */
     @Test
@@ -277,6 +297,46 @@ public class FileHashStoreInterfaceTest {
 
         InputStream dataStream = Files.newInputStream(testDataFile);
         fileHashStore.storeObject(dataStream, pid, null, null, "SHA-512/224", 0);
+    }
+
+    /**
+     * Check that store object throws exception when incorrect file size provided
+     */
+    @Test
+    public void storeObject_objSizeCorrect() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, objectSize
+            );
+
+            // Check id (sha-256 hex digest of the ab_id (pid))
+            assertEquals(objectSize, objInfo.getSize());
+        }
+    }
+
+    /**
+     * Check that store object throws exception when incorrect file size provided
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void storeObject_objSizeIncorrect() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, 1000
+            );
+
+            // Check id (sha-256 hex digest of the ab_id (pid))
+            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
+            assertEquals(objectSize, objInfo.getSize());
+        }
     }
 
     /**

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -124,7 +124,7 @@ public class FileHashStoreInterfaceTest {
                 dataStream, pid, null, null, null, 0
             );
 
-            // Check id (sha-256 hex digest of the ab_id (pid))
+            // Check the object size
             long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
             assertEquals(objectSize, objInfo.getSize());
         }
@@ -213,6 +213,63 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, "", null, null, null, 0);
+        }
+    }
+
+    /**
+     * Verify that storeObject generates an additional checksum with overloaded method
+     */
+    @Test
+    public void storeObject_additionalAlgorithm_overload() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, "MD2");
+
+            Map<String, String> hexDigests = objInfo.getHexDigests();
+
+            // Validate checksum values
+            String md2 = testData.pidData.get(pid).get("md2");
+            assertEquals(md2, hexDigests.get("MD2"));
+        }
+    }
+
+    /**
+     * Verify that storeObject validates checksum with overloaded method
+     */
+    @Test
+    public void storeObject_validateChecksum_overload() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+            String md2 = testData.pidData.get(pid).get("md2");
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, md2, "MD2");
+
+            Map<String, String> hexDigests = objInfo.getHexDigests();
+
+            // Validate checksum values
+            assertEquals(md2, hexDigests.get("MD2"));
+        }
+    }
+
+    /**
+     * Check that store object returns the correct ObjectMetadata size
+     */
+    @Test
+    public void storeObject_objSize_overload() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, objectSize);
+
+            assertEquals(objectSize, objInfo.getSize());
         }
     }
 
@@ -343,7 +400,7 @@ public class FileHashStoreInterfaceTest {
      * Verify exception thrown when unsupported additional algorithm provided
      */
     @Test(expected = NoSuchAlgorithmException.class)
-    public void put_invalidAlgorithm() throws Exception {
+    public void storeObject_invalidAlgorithm() throws Exception {
         // Get single test file to "upload"
         String pid = "jtao.1700.1";
         Path testDataFile = testData.getTestFile(pid);

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -992,6 +992,25 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
+     * Check that retrieveMetadata returns an InputStream with overload method
+     */
+    @Test
+    public void retrieveMetadata_overload() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test metadata file
+            Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
+
+            InputStream metadataStream = Files.newInputStream(testMetaDataFile);
+            fileHashStore.storeMetadata(metadataStream, pid, null);
+
+            InputStream metadataCidInputStream = fileHashStore.retrieveMetadata(pid);
+            assertNotNull(metadataCidInputStream);
+        }
+    }
+
+    /**
      * Check that retrieveMetadata throws exception when pid is null
      */
     @Test(expected = NullPointerException.class)
@@ -1182,7 +1201,7 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Confirm that deleteMetadata deletes object and empty sub directories
+     * Confirm that deleteMetadata deletes metadata and empty sub directories
      */
     @Test
     public void deleteMetadata() throws Exception {
@@ -1200,6 +1219,35 @@ public class FileHashStoreInterfaceTest {
             assertTrue(isMetadataDeleted);
 
             // Double check that file doesn't exist
+            Path metadataCidPath = fileHashStore.getRealPath(pid, "metadata", storeFormatId);
+            assertFalse(Files.exists(metadataCidPath));
+
+            // Double check that metadata directory still exists
+            Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
+            Path storeObjectPath = storePath.resolve("metadata");
+            assertTrue(Files.exists(storeObjectPath));
+        }
+    }
+
+    /**
+     * Confirm that deleteMetadata deletes object and empty subdirectories with overload method
+     */
+    @Test
+    public void deleteMetadata_overload() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test metadata file
+            Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
+
+            InputStream metadataStream = Files.newInputStream(testMetaDataFile);
+            fileHashStore.storeMetadata(metadataStream, pid, null);
+
+            boolean isMetadataDeleted = fileHashStore.deleteMetadata(pid);
+            assertTrue(isMetadataDeleted);
+
+            // Double check that file doesn't exist
+            String storeFormatId = (String) fhsProperties.get("storeMetadataNamespace");
             Path metadataCidPath = fileHashStore.getRealPath(pid, "metadata", storeFormatId);
             assertFalse(Files.exists(metadataCidPath));
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -674,6 +674,36 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
+     * Test storeMetadata with overload method (default namespace)
+     */
+    @Test
+    public void storeMetadata_defaultFormatId_overload() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+
+            // Get test metadata file
+            Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
+
+            InputStream metadataStream = Files.newInputStream(testMetaDataFile);
+            String metadataCid = fileHashStore.storeMetadata(metadataStream, pid);
+
+            // Get relative path
+            String metadataCidShardString = fileHashStore.getHierarchicalPathString(
+                3, 2, metadataCid
+            );
+            // Get absolute path
+            Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
+            Path metadataCidAbsPath = storePath.resolve("metadata/" + metadataCidShardString);
+
+            assertTrue(Files.exists(metadataCidAbsPath));
+
+            long writtenMetadataFile = Files.size(testMetaDataFile);
+            long originalMetadataFie = Files.size(metadataCidAbsPath);
+            assertEquals(writtenMetadataFile, originalMetadataFie);
+        }
+    }
+
+    /**
      * Test storeMetadata stores the expected amount of bytes
      */
     @Test

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.dataone.hashstore.HashAddress;
+import org.dataone.hashstore.ObjectMetadata;
 import org.dataone.hashstore.exceptions.PidObjectExistsException;
 import org.dataone.hashstore.testdata.TestDataHarness;
 import org.junit.Before;
@@ -200,7 +200,7 @@ public class FileHashStoreProtectedTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress address = fileHashStore.putObject(dataStream, pid, null, null, null);
+            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null);
 
             // Check id (sha-256 hex digest of the ab_id, aka object_cid)
             String objAuthorityId = testData.pidData.get(pid).get("object_cid");
@@ -218,7 +218,7 @@ public class FileHashStoreProtectedTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress address = fileHashStore.putObject(dataStream, pid, null, null, null);
+            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null);
 
             // Check duplicate status
             assertFalse(address.getIsDuplicate());
@@ -235,7 +235,7 @@ public class FileHashStoreProtectedTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            HashAddress address = fileHashStore.putObject(dataStream, pid, null, null, null);
+            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null);
 
             Map<String, String> hexDigests = address.getHexDigests();
 
@@ -265,7 +265,7 @@ public class FileHashStoreProtectedTest {
         String checksumCorrect = "9c25df1c8ba1d2e57bb3fd4785878b85";
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        HashAddress address = fileHashStore.putObject(
+        ObjectMetadata address = fileHashStore.putObject(
             dataStream, pid, null, checksumCorrect, "MD2"
         );
 
@@ -373,7 +373,7 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        HashAddress address = fileHashStore.putObject(dataStream, pid, null, null, null);
+        ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null);
 
         // Check duplicate status
         assertFalse(address.getIsDuplicate());

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -200,7 +200,7 @@ public class FileHashStoreProtectedTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null);
+            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null, 0);
 
             // Check id (sha-256 hex digest of the ab_id, aka object_cid)
             String objAuthorityId = testData.pidData.get(pid).get("object_cid");
@@ -218,7 +218,7 @@ public class FileHashStoreProtectedTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null);
+            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null, 0);
 
             // Check duplicate status
             assertFalse(address.getIsDuplicate());
@@ -235,7 +235,7 @@ public class FileHashStoreProtectedTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null);
+            ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null, 0);
 
             Map<String, String> hexDigests = address.getHexDigests();
 
@@ -266,7 +266,7 @@ public class FileHashStoreProtectedTest {
 
         InputStream dataStream = Files.newInputStream(testDataFile);
         ObjectMetadata address = fileHashStore.putObject(
-            dataStream, pid, null, checksumCorrect, "MD2"
+            dataStream, pid, null, checksumCorrect, "MD2", 0
         );
 
         String objCid = address.getId();
@@ -291,7 +291,7 @@ public class FileHashStoreProtectedTest {
         String checksumCorrect = "9c25df1c8ba1d2e57bb3fd4785878b85";
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pid, "MD2", null, null);
+        fileHashStore.putObject(dataStream, pid, "MD2", null, null, 0);
 
         String md2 = testData.pidData.get(pid).get("md2");
         assertEquals(checksumCorrect, md2);
@@ -309,7 +309,7 @@ public class FileHashStoreProtectedTest {
         String checksumIncorrect = "1c25df1c8ba1d2e57bb3fd4785878b85";
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pid, null, checksumIncorrect, "MD2");
+        fileHashStore.putObject(dataStream, pid, null, checksumIncorrect, "MD2", 0);
     }
 
     /**
@@ -322,7 +322,7 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pid, null, "   ", "MD2");
+        fileHashStore.putObject(dataStream, pid, null, "   ", "MD2", 0);
     }
 
     /**
@@ -335,7 +335,7 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pid, null, null, "MD2");
+        fileHashStore.putObject(dataStream, pid, null, null, "MD2", 0);
     }
 
     /**
@@ -348,7 +348,7 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pid, null, "abc", "   ");
+        fileHashStore.putObject(dataStream, pid, null, "abc", "   ", 0);
     }
 
     /**
@@ -360,7 +360,7 @@ public class FileHashStoreProtectedTest {
         String pid = "jtao.1700.1";
         Path testDataFile = testData.getTestFile(pid);
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pid, null, "abc", null);
+        fileHashStore.putObject(dataStream, pid, null, "abc", null, 0);
     }
 
     /**
@@ -373,14 +373,14 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null);
+        ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null, 0);
 
         // Check duplicate status
         assertFalse(address.getIsDuplicate());
 
         // Try duplicate upload
         InputStream dataStreamTwo = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStreamTwo, pid, null, null, null);
+        fileHashStore.putObject(dataStreamTwo, pid, null, null, null, 0);
     }
 
     /**
@@ -393,7 +393,7 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pid, "SM2", null, null);
+        fileHashStore.putObject(dataStream, pid, "SM2", null, null, 0);
     }
 
     /**
@@ -406,7 +406,7 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pid, "   ", null, null);
+        fileHashStore.putObject(dataStream, pid, "   ", null, null, 0);
     }
 
     /**
@@ -420,7 +420,7 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, pidEmpty, null, null, null);
+        fileHashStore.putObject(dataStream, pidEmpty, null, null, null, 0);
     }
 
     /**
@@ -433,7 +433,7 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
 
         InputStream dataStream = Files.newInputStream(testDataFile);
-        fileHashStore.putObject(dataStream, null, "MD2", null, null);
+        fileHashStore.putObject(dataStream, null, "MD2", null, null, 0);
     }
 
     /**
@@ -444,7 +444,7 @@ public class FileHashStoreProtectedTest {
         // Get test file to "upload"
         String pid = "jtao.1700.1";
 
-        fileHashStore.putObject(null, pid, "MD2", null, null);
+        fileHashStore.putObject(null, pid, "MD2", null, null, 0);
     }
 
     /**

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -209,6 +209,25 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
+     * Check that store object returns the correct ObjectMetadata size
+     */
+    @Test
+    public void putObject_objSize() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.putObject(dataStream, pid, null, null, null, 0);
+
+            // Check id (sha-256 hex digest of the ab_id (pid))
+            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
+            assertEquals(objectSize, objInfo.getSize());
+        }
+    }
+
+
+    /**
      * Verify that putObject returns expected isDuplicate value: false
      */
     @Test
@@ -361,6 +380,47 @@ public class FileHashStoreProtectedTest {
         Path testDataFile = testData.getTestFile(pid);
         InputStream dataStream = Files.newInputStream(testDataFile);
         fileHashStore.putObject(dataStream, pid, null, "abc", null, 0);
+    }
+
+
+    /**
+     * Check that store object throws exception when incorrect file size provided
+     */
+    @Test
+    public void putObject_objSizeCorrect() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.putObject(
+                dataStream, pid, null, null, null, objectSize
+            );
+
+            // Check id (sha-256 hex digest of the ab_id (pid))
+            assertEquals(objectSize, objInfo.getSize());
+        }
+    }
+
+    /**
+     * Check that store object throws exception when incorrect file size provided
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void putObject_objSizeIncorrect() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.putObject(
+                dataStream, pid, null, null, null, 1000
+            );
+
+            // Check id (sha-256 hex digest of the ab_id (pid))
+            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
+            assertEquals(objectSize, objInfo.getSize());
+        }
     }
 
     /**

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -406,7 +406,7 @@ public class FileHashStorePublicTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
 
             InputStream dataStream = Files.newInputStream(testDataFile);
-            secondHashStore.storeObject(dataStream, pid, null, null, null);
+            secondHashStore.storeObject(dataStream, pid, null, null, null, 0);
         }
 
         // Delete configuration

--- a/src/test/java/org/dataone/hashstore/testdata/TestDataHarness.java
+++ b/src/test/java/org/dataone/hashstore/testdata/TestDataHarness.java
@@ -11,65 +11,113 @@ import java.util.Map;
  * 
  * Notes:
  * - "object_cid" is the SHA-256 hash of the pid
- * - algorithms without any prefixes are the algorithm hash of the pid's respective data object content
+ * - algorithms without any prefixes are the algorithm hash of the pid's respective data object
+ * content
  * - "metadata_sha256" is the hash of the pid's respective metadata object content
  * 
  */
 public class TestDataHarness {
         public Map<String, Map<String, String>> pidData;
-        public String[] pidList = { "doi:10.18739/A2901ZH2M", "jtao.1700.1",
-                        "urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a" };
+        public String[] pidList = {"doi:10.18739/A2901ZH2M", "jtao.1700.1",
+                "urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a"};
 
         public TestDataHarness() {
                 Map<String, Map<String, String>> pidsAndHexDigests = new HashMap<>();
 
                 Map<String, String> values1 = new HashMap<>();
-                values1.put("object_cid", "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e");
+                values1.put(
+                        "object_cid",
+                        "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e"
+                );
                 values1.put("md2", "b33c730ac5e36b2b886a9cd14552f42e");
                 values1.put("md5", "db91c910a3202478c8def1071c54aae5");
                 values1.put("sha1", "1fe86e3c8043afa4c70857ca983d740ad8501ccd");
-                values1.put("sha256", "4d198171eef969d553d4c9537b1811a7b078f9a3804fc978a761bc014c05972c");
-                values1.put("sha384",
-                                "d5953bd802fa74edea72eb941ead7a27639e62792fedc065d6c81de6c613b5b8739ab1f90e7f24a7500d154a727ed7c2");
-                values1.put("sha512",
-                                "e9bcd6b91b102ef5803d1bd60c7a5d2dbec1a2baf5f62f7da60de07607ad6797d6a9b740d97a257fd2774f2c26503d455d8f2a03a128773477dfa96ab96a2e54");
-                values1.put("sha512-224", "107f9facb268471de250625440b6c8b7ff8296fbe5d89bed4a61fd35");
-                values1.put("metadata_sha256", "158d7e55c36a810d7c14479c952a4d0b370f2b844808f2ea2b20d7df66768b04");
+                values1.put(
+                        "sha256", "4d198171eef969d553d4c9537b1811a7b078f9a3804fc978a761bc014c05972c"
+                );
+                values1.put(
+                        "sha384",
+                        "d5953bd802fa74edea72eb941ead7a27639e62792fedc065d6c81de6c613b5b8739ab1f90e7f24a7500d154a727ed7c2"
+                );
+                values1.put(
+                        "sha512",
+                        "e9bcd6b91b102ef5803d1bd60c7a5d2dbec1a2baf5f62f7da60de07607ad6797d6a9b740d97a257fd2774f2c26503d455d8f2a03a128773477dfa96ab96a2e54"
+                );
+                values1.put(
+                        "sha512-224", "107f9facb268471de250625440b6c8b7ff8296fbe5d89bed4a61fd35"
+                );
+                values1.put(
+                        "metadata_sha256",
+                        "158d7e55c36a810d7c14479c952a4d0b370f2b844808f2ea2b20d7df66768b04"
+                );
+                values1.put("size", "39993");
                 pidsAndHexDigests.put("doi:10.18739/A2901ZH2M", values1);
 
                 Map<String, String> values2 = new HashMap<>();
-                values2.put("object_cid", "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf");
+                values2.put(
+                        "object_cid",
+                        "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf"
+                );
                 values2.put("md2", "9c25df1c8ba1d2e57bb3fd4785878b85");
                 values2.put("md5", "f4ea2d07db950873462a064937197b0f");
                 values2.put("sha1", "3d25436c4490b08a2646e283dada5c60e5c0539d");
-                values2.put("sha256", "94f9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a");
-                values2.put("sha384",
-                                "a204678330fcdc04980c9327d4e5daf01ab7541e8a351d49a7e9c5005439dce749ada39c4c35f573dd7d307cca11bea8");
-                values2.put("sha512",
-                                "bf9e7f4d4e66bd082817d87659d1d57c2220c376cd032ed97cadd481cf40d78dd479cbed14d34d98bae8cebc603b40c633d088751f07155a94468aa59e2ad109");
-                values2.put("sha512-224", "7a2b22e36ced9e91cf8cdf6971897ec4ae21780e11d1c3903011af33");
-                values2.put("metadata_sha256", "d87c386943ceaeba5644c52b23111e4f47972e6530df0e6f0f41964b25855b08");
+                values2.put(
+                        "sha256", "94f9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a"
+                );
+                values2.put(
+                        "sha384",
+                        "a204678330fcdc04980c9327d4e5daf01ab7541e8a351d49a7e9c5005439dce749ada39c4c35f573dd7d307cca11bea8"
+                );
+                values2.put(
+                        "sha512",
+                        "bf9e7f4d4e66bd082817d87659d1d57c2220c376cd032ed97cadd481cf40d78dd479cbed14d34d98bae8cebc603b40c633d088751f07155a94468aa59e2ad109"
+                );
+                values2.put(
+                        "sha512-224", "7a2b22e36ced9e91cf8cdf6971897ec4ae21780e11d1c3903011af33"
+                );
+                values2.put(
+                        "metadata_sha256",
+                        "d87c386943ceaeba5644c52b23111e4f47972e6530df0e6f0f41964b25855b08"
+                );
+                values2.put("size", "8724");
                 pidsAndHexDigests.put("jtao.1700.1", values2);
 
                 Map<String, String> values3 = new HashMap<>();
-                values3.put("object_cid", "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6");
+                values3.put(
+                        "object_cid",
+                        "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6"
+                );
                 values3.put("md2", "9f2b06b300f661ce4398006c41d8aa88");
                 values3.put("md5", "e1932fc75ca94de8b64f1d73dc898079");
                 values3.put("sha1", "c6d2a69a3f5adaf478ba796c114f57b990cf7ad1");
-                values3.put("sha256", "4473516a592209cbcd3a7ba4edeebbdb374ee8e4a49d19896fafb8f278dc25fa");
-                values3.put("sha384",
-                                "b1023a9be5aa23a102be9bce66e71f1f1c7a6b6b03e3fc603e9cd36b4265671e94f9cc5ce3786879740536994489bc26");
-                values3.put("sha512",
-                                "c7fac7e8aacde8546ddb44c640ad127df82830bba6794aea9952f737c13a81d69095865ab3018ed2a807bf9222f80657faf31cfde6c853d7b91e617e148fec76");
-                values3.put("sha512-224", "e1789a91c9df334fdf6ee5d295932ad96028c426a18b17016a627099");
-                values3.put("metadata_sha256", "27003e07f2ab374020de73298dd24a1d8b1b57647b8fa3c49db00f8c342afa1d");
+                values3.put(
+                        "sha256", "4473516a592209cbcd3a7ba4edeebbdb374ee8e4a49d19896fafb8f278dc25fa"
+                );
+                values3.put(
+                        "sha384",
+                        "b1023a9be5aa23a102be9bce66e71f1f1c7a6b6b03e3fc603e9cd36b4265671e94f9cc5ce3786879740536994489bc26"
+                );
+                values3.put(
+                        "sha512",
+                        "c7fac7e8aacde8546ddb44c640ad127df82830bba6794aea9952f737c13a81d69095865ab3018ed2a807bf9222f80657faf31cfde6c853d7b91e617e148fec76"
+                );
+                values3.put(
+                        "sha512-224", "e1789a91c9df334fdf6ee5d295932ad96028c426a18b17016a627099"
+                );
+                values3.put(
+                        "metadata_sha256",
+                        "27003e07f2ab374020de73298dd24a1d8b1b57647b8fa3c49db00f8c342afa1d"
+                );
+                values3.put("size", "18699");
                 pidsAndHexDigests.put("urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a", values3);
 
                 this.pidData = pidsAndHexDigests;
         }
 
         public Path getTestFile(String pid) {
-                Path testdataDirectory = Paths.get("src/test/java/org/dataone/hashstore", "testdata", pid);
+                Path testdataDirectory = Paths.get(
+                        "src/test/java/org/dataone/hashstore", "testdata", pid
+                );
                 String testdataAbsolutePath = testdataDirectory.toFile().getAbsolutePath();
                 Path testDataFile = new File(testdataAbsolutePath).toPath();
                 return testDataFile;


### PR DESCRIPTION
Summary of Changes:
- Refactored `HashAddress` to `ObjectMetadata` and update all junit tests
- Added new attribute to `ObjectMetadata` for size and validating when an expected object size is provided
- Overloaded `storeObject` method to remove usage of `null` when calling method and to allow for convenient calls to specifically validate object size, compare checksums and generate an additional hex digest/hash
- Overloaded `storeMetadata`, `retrieveMetadata` and `deleteMetadata` to enable calling of methods with default store metadata namespace (`formatId`) value
- Small refactor for `loadHashStoreYaml` to reference enum values rather than use specific strings for the keys when creating the HashMap object