### PR TITLE
Feature-39: HashStore-java Client App

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,41 @@ and then install or build the package with `mvn install` or `mvn package`, respe
 
 We also maintain a parallel [Python-based version of HashStore](https://github.com/DataONEorg/hashstore).
 
+## Usage Example
+
+How to use HashStore Java client (command line app)
+```
+# Step 1: Get HashStore Client Jar file
+> mvn clean package -Dmaven.test.skip=true
+
+# Step 2:
+## Create a HashStore (long option)
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client --createhashstore --storepath=/path/to/store --storedepth=3 --storewidth=2 --storealgo=SHA-256 --storenamespace=http://ns.dataone.org/service/types/v2.0
+## Create a HashStore (short option)
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client -chs -store /path/to/store -dp 3 -wp 2 -ap SHA-256 -nsp http://ns.dataone.org/service/types/v2
+
+# Get the checksum of a data object
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client -store /path/to/store -getchecksum -pid testpid1 -algo SHA-256
+
+# Store a data object
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client -store /path/to/store -storeobject -path /path/to/data.ext -pid testpid1
+
+# Store a metadata object
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client -store /path/to/store -storemetadata -path /path/to/metadata.ext -pid testpid1 -format_id http://ns.dataone.org/service/types/v2
+
+# Retrieve a data object
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client -store /path/to/store -retrieveobject -pid testpid1
+
+# Retrieve a metadata object
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client -store /path/to/store -retrievemetadata -pid testpid1 -format_id http://ns.dataone.org/service/types/v2
+
+# Delete a data object
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client -store /path/to/store -deleteobject -pid testpid1
+
+# Delete a metadata file
+> java -cp /path/to/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.Client -store /path/to/store -deletemetadata -pid testpid1 -format_id http://ns.dataone.org/service/types/v2
+```
+
 ## License
 
 ```txt

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
       <version>2.15.2</version>
     </dependency>
     <dependency>
-        <groupId>org.postgresql</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>42.4.3</version>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.4.3</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,29 @@
         <!-- default lifecycle, jar packaging: see
         https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.1</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        <manifestEntries>
+                          <Main-Class>org.dataone.hashstore.Client</Main-Class>
+                          <Build-Number>${project.version}</Build-Number>
+                        </manifestEntries>
+                    </transformer>
+                </transformers>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.3.0</version>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
       <version>1.2</version>
     </dependency>
     <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,73 @@
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to
-      parent pom) -->
+    <!-- <pluginManagement> -->
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+              <source>8</source>
+              <target>8</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.1</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                  <goal>shade</goal>
+              </goals>
+              <configuration>
+                <transformers>
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                    <manifestEntries>
+                        <Main-Class>org.dataone.hashstore.Client</Main-Class>
+                        <Build-Number>${project.version}</Build-Number>
+                    </manifestEntries>
+                  </transformer>
+                </transformers>
+                <!--
+                See https://issues.apache.org/jira/browse/LOG4J2-673
+                and https://stackoverflow.com/questions/48033792/log4j2-error-statuslogger-unrecognized-conversion-specifier
+                -->
+                <filters>
+                  <filter>
+                    <artifact>*:*</artifact>
+                    <excludes>
+                        <exclude>**/Log4j2Plugins.dat</exclude>
+                    </excludes>
+                  </filter>
+                  <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                  </filter>
+                </filters>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+            <executions>
+                <execution>
+                    <id>default-jar</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
         <!-- clean lifecycle, see
         https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
@@ -61,43 +125,12 @@
         <!-- default lifecycle, jar packaging: see
         https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.1</version>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>shade</goal>
-              </goals>
-              <configuration>
-                <transformers>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                        <manifestEntries>
-                          <Main-Class>org.dataone.hashstore.Client</Main-Class>
-                          <Build-Number>${project.version}</Build-Number>
-                        </manifestEntries>
-                    </transformer>
-                </transformers>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.3.0</version>
         </plugin>
         <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
@@ -118,6 +151,6 @@
           <version>3.4.2</version>
         </plugin>
       </plugins>
-    </pluginManagement>
+    <!-- </pluginManagement> -->
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
       <artifactId>jackson-databind</artifactId>
       <version>2.15.2</version>
     </dependency>
+    <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>42.4.3</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -74,46 +74,51 @@ public class Client {
             while (resultSet.next()) {
                 System.out.println("Calling resultSet.next()");
                 String guid = resultSet.getString("guid");
-                // String docid = resultSet.getString("docid");
-                // int rev = resultSet.getInt("rev");
-                // String name = resultSet.getString("name");
+                String docid = resultSet.getString("docid");
+                int rev = resultSet.getInt("rev");
                 String checksum = resultSet.getString("checksum");
                 String checksumAlgorithm = resultSet.getString("checksum_algorithm");
                 String formattedAlgo = formatAlgo(checksumAlgorithm);
 
-                // Retrieve object
-                System.out.println("Retrieving object for guid: " + guid);
-                InputStream objstream = hashStore.retrieveObject(guid);
+                Path setItemFilePath = Paths.get("/var/metacata/data/" + docid + "." + rev);
+                if (Files.exists(setItemFilePath)) {
+                    System.out.println("File exists at: " + setItemFilePath);
 
-                // Get hex digest
-                System.out.println("Calculating hex digest with algorithm: " + formattedAlgo);
-                String streamDigest = calculateHexDigest(objstream, formattedAlgo);
+                    // Retrieve object
+                    System.out.println("Retrieving object for guid: " + guid);
+                    InputStream objstream = hashStore.retrieveObject(guid);
 
-                // If checksums don't match, write a .txt file
-                if (!streamDigest.equals(checksum)) {
-                    // Create directory to store the error files
-                    Path errorDirectory = Paths.get(
-                        "/home/mok/testing/knbvm_hashstore/java/obj/errors"
-                    );
-                    Files.createDirectories(errorDirectory);
-                    Path objectErrorTxtFile = errorDirectory.resolve(guid + ".txt");
+                    // Get hex digest
+                    System.out.println("Calculating hex digest with algorithm: " + formattedAlgo);
+                    String streamDigest = calculateHexDigest(objstream, formattedAlgo);
 
-                    String errMsg = "Obj retrieved (pid/guid): " + guid
-                        + ". Checksums do not match, checksum from db: " + checksum
-                        + ". Calculated digest: " + streamDigest + ". Algorithm: " + formattedAlgo;
+                    // If checksums don't match, write a .txt file
+                    if (!streamDigest.equals(checksum)) {
+                        // Create directory to store the error files
+                        Path errorDirectory = Paths.get(
+                            "/home/mok/testing/knbvm_hashstore/java/obj/errors"
+                        );
+                        Files.createDirectories(errorDirectory);
+                        Path objectErrorTxtFile = errorDirectory.resolve(guid + ".txt");
 
-                    try (BufferedWriter writer = new BufferedWriter(
-                        new OutputStreamWriter(
-                            Files.newOutputStream(objectErrorTxtFile), StandardCharsets.UTF_8
-                        )
-                    )) {
-                        writer.write(errMsg);
+                        String errMsg = "Obj retrieved (pid/guid): " + guid
+                            + ". Checksums do not match, checksum from db: " + checksum
+                            + ". Calculated digest: " + streamDigest + ". Algorithm: "
+                            + formattedAlgo;
 
-                    } catch (Exception e) {
-                        e.printStackTrace();
+                        try (BufferedWriter writer = new BufferedWriter(
+                            new OutputStreamWriter(
+                                Files.newOutputStream(objectErrorTxtFile), StandardCharsets.UTF_8
+                            )
+                        )) {
+                            writer.write(errMsg);
+
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        System.out.println("Checksums match!");
                     }
-                } else {
-                    System.out.println("Checksums match!");
                 }
             }
 

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -429,9 +429,9 @@ public class Client {
                 String formattedChecksumAlgo = formatAlgo(checksumAlgorithm);
                 String formatId = resultSet.getString("object_format");
 
-                if (!objType.equals("data")) {
-                    if (!objType.equals("documents")) {
-                        String errMsg = "HashStoreClient - objType must be 'data' or 'documents'";
+                if (!objType.equals("object")) {
+                    if (!objType.equals("metadata")) {
+                        String errMsg = "HashStoreClient - objType must be 'object' or 'metadata'";
                         throw new IllegalArgumentException(errMsg);
                     }
                 }
@@ -452,22 +452,22 @@ public class Client {
             }
 
             // Check options
-            if (actionFlag.equals("sts") && objType.equals("data")) {
+            if (actionFlag.equals("sts") && objType.equals("object")) {
                 storeObjsWithChecksumFromDb(resultObjList);
             }
-            if (actionFlag.equals("sts") && objType.equals("documents")) {
+            if (actionFlag.equals("sts") && objType.equals("metadata")) {
                 storeMetadataFromDb(resultObjList);
             }
-            if (actionFlag.equals("rav") && objType.equals("data")) {
+            if (actionFlag.equals("rav") && objType.equals("object")) {
                 retrieveAndValidateObjs(resultObjList);
             }
-            if (actionFlag.equals("rav") && objType.equals("documents")) {
+            if (actionFlag.equals("rav") && objType.equals("metadata")) {
                 retrieveAndValidateMetadata(resultObjList);
             }
-            if (actionFlag.equals("dfs") && objType.equals("data")) {
+            if (actionFlag.equals("dfs") && objType.equals("object")) {
                 deleteObjectsFromStore(resultObjList);
             }
-            if (actionFlag.equals("dfs") && objType.equals("documents")) {
+            if (actionFlag.equals("dfs") && objType.equals("metadata")) {
                 deleteMetadataFromStore(resultObjList);
             }
 

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -48,6 +48,7 @@ public class Client {
         initializeHashStore(storePath);
 
         // Load metacat db yaml
+        System.out.println("Loading metacat db yaml.");
         Path pgdbYaml = storePath.resolve("pgdb.yaml");
         File pgdbYamlFile = pgdbYaml.toFile();
         ObjectMapper om = new ObjectMapper(new YAMLFactory());
@@ -58,6 +59,7 @@ public class Client {
         String password = (String) pgdbYamlProperties.get("db_password");
 
         try {
+            System.out.println("Connecting to metacat db.");
             // Setup metacat db access
             Connection connection = DriverManager.getConnection(url, user, password);
             Statement statement = connection.createStatement();

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -25,6 +25,7 @@ import java.sql.Statement;
 import javax.xml.bind.DatatypeConverter;
 
 import org.dataone.hashstore.exceptions.HashStoreFactoryException;
+import org.dataone.hashstore.exceptions.PidObjectExistsException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -111,6 +112,14 @@ public class Client {
                 // Store object
                 System.out.println("Storing object for guid: " + guid);
                 hashStore.storeObject(objStream, guid, checksum, algorithm);
+
+            } catch (PidObjectExistsException poee) {
+                String errMsg = "Unexpected Error: " + poee.fillInStackTrace();
+                try {
+                    logExceptionToFile(guid, errMsg, "java/store_errors/illegalargument");
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
 
             } catch (IllegalArgumentException iae) {
                 String errMsg = "Unexpected Error: " + iae.fillInStackTrace();

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -114,7 +114,7 @@ public class Client {
                 hashStore.storeObject(objStream, guid, checksum, algorithm);
 
             } catch (PidObjectExistsException poee) {
-                poee.printStackTrace();
+                System.out.println("Object already exists for pid: " + guid);
                 // String errMsg = "Unexpected Error: " + poee.fillInStackTrace();
                 // try {
                 //     logExceptionToFile(guid, errMsg, "java/store_errors/pidobjectexists");

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -71,6 +71,7 @@ public class Client {
 
             // For each row, get guid, docid, rev, checksum and checksum_algorithm
             while (resultSet.next()) {
+                System.out.println("Calling resultSet.next()");
                 String guid = resultSet.getString("guid");
                 // String docid = resultSet.getString("docid");
                 // int rev = resultSet.getInt("rev");
@@ -107,7 +108,7 @@ public class Client {
                         writer.write(errMsg);
 
                     } catch (Exception e) {
-                        e.fillInStackTrace();
+                        e.printStackTrace();
                     }
                 } else {
                     System.out.println("Checksums match!");
@@ -120,7 +121,7 @@ public class Client {
             connection.close();
 
         } catch (Exception e) {
-            e.fillInStackTrace();
+            e.printStackTrace();
         }
 
     }
@@ -193,7 +194,7 @@ public class Client {
             stream.close();
 
         } catch (IOException ioe) {
-            ioe.fillInStackTrace();
+            ioe.printStackTrace();
 
         }
         // mdObjectHexDigest

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -34,7 +34,7 @@ public class Client {
 
     public static void main(String[] args) throws Exception {
         // Get a HashStore
-        Path storePath = Paths.get("/home/mok/testing/knbvm_hashstore");
+        Path storePath = Paths.get("/home/mok/testing/knbvm_testlog");
         initializeHashStore(storePath);
 
         // Load metacat db yaml
@@ -57,7 +57,7 @@ public class Client {
             String sqlQuery = "SELECT identifier.guid, identifier.docid, identifier.rev,"
                 + " systemmetadata.object_format, systemmetadata.checksum,"
                 + " systemmetadata.checksum_algorithm FROM identifier INNER JOIN systemmetadata"
-                + " ON identifier.guid = systemmetadata.guid";
+                + " ON identifier.guid = systemmetadata.guid LIMIT 100000;";
             ResultSet resultSet = statement.executeQuery(sqlQuery);
 
             // For each row, get guid, docid, rev, checksum and checksum_algorithm

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -34,7 +34,7 @@ public class Client {
 
     public static void main(String[] args) throws Exception {
         // Get a HashStore
-        Path storePath = Paths.get("/home/mok/testing/knbvm_testlog");
+        Path storePath = Paths.get("/home/mok/testing/knbvm_hashstore");
         initializeHashStore(storePath);
 
         // Load metacat db yaml
@@ -57,7 +57,7 @@ public class Client {
             String sqlQuery = "SELECT identifier.guid, identifier.docid, identifier.rev,"
                 + " systemmetadata.object_format, systemmetadata.checksum,"
                 + " systemmetadata.checksum_algorithm FROM identifier INNER JOIN systemmetadata"
-                + " ON identifier.guid = systemmetadata.guid LIMIT 10000;";
+                + " ON identifier.guid = systemmetadata.guid";
             ResultSet resultSet = statement.executeQuery(sqlQuery);
 
             // For each row, get guid, docid, rev, checksum and checksum_algorithm

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -74,9 +74,17 @@ public class Client {
                     System.out.println(
                         "Testing with KNBVM values. Please ensure all config files present."
                     );
-                    // TODO: Pass to method based on getOptions
-                    String action = "sts";
-                    String objType = "data"; // Or "documents"
+                    String action = null;
+                    if (cmd.hasOption("sts")) {
+                        action = "sts";
+                    }
+                    if (cmd.hasOption("rav")) {
+                        action = "rav";
+                    }
+                    if (cmd.hasOption("dfs")) {
+                        action = "dfs";
+                    }
+                    String objType = cmd.getOptionValue("stype");
                     testWithKnbvm(action, objType);
                 }
             }
@@ -133,9 +141,11 @@ public class Client {
                 String formattedChecksumAlgo = formatAlgo(checksumAlgorithm);
                 String formatId = resultSet.getString("object_format");
 
-                if (objType != "data" || objType != "documents") {
-                    String errMsg = "HashStoreClient - objType must be 'data' or 'documents'";
-                    throw new IllegalArgumentException(errMsg);
+                if (!objType.equals("data")) {
+                    if (!objType.equals("documents")) {
+                        String errMsg = "HashStoreClient - objType must be 'data' or 'documents'";
+                        throw new IllegalArgumentException(errMsg);
+                    }
                 }
                 Path setItemFilePath = Paths.get(
                     "/var/metacat/" + objType + "/" + docid + "." + rev
@@ -153,22 +163,22 @@ public class Client {
             }
 
             // Check options
-            if (actionFlag == "sts" && objType == "data") {
+            if (actionFlag.equals("sts") && objType.equals("data")) {
                 storeObjsWithChecksumFromDb(resultObjList);
             }
-            if (actionFlag == "sts" && objType == "documents") {
+            if (actionFlag.equals("sts") && objType.equals("documents")) {
                 storeMetadataFromDb(resultObjList);
             }
-            if (actionFlag == "rav" && objType == "data") {
+            if (actionFlag.equals("rav") && objType.equals("data")) {
                 retrieveAndValidateObjs(resultObjList);
             }
-            if (actionFlag == "rav" && objType == "documents") {
+            if (actionFlag.equals("rav") && objType.equals("documents")) {
                 retrieveAndValidateMetadata(resultObjList);
             }
-            if (actionFlag == "dfs" && objType == "data") {
+            if (actionFlag.equals("dfs") && objType.equals("data")) {
                 deleteObjectsFromStore(resultObjList);
             }
-            if (actionFlag == "dfs" && objType == "documents") {
+            if (actionFlag.equals("dfs") && objType.equals("documents")) {
                 deleteMetadataFromStore(resultObjList);
             }
 

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -158,7 +158,7 @@ public class Client {
                     );
                     pidObjStream.close();
                     System.out.println("Object Info for pid (" + pid + "):");
-                    System.out.println(objInfo);
+                    System.out.println(objInfo.getHexDigests());
 
                 } else if (cmd.hasOption("storemetadata")) {
                     String pid = cmd.getOptionValue("pid");

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -165,6 +165,7 @@ public class Client {
 
         // Get HashStore
         hashStore = HashStoreFactory.getHashStore(classPackage, storeProperties);
+        return;
     }
 
     /**

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -44,20 +44,19 @@ public class Client {
         if (args.length == 0) {
             System.out.println("No arguments provided. Use flag '-h' for help.");
         }
-        Options options = new Options();
-        options.addOption("h", "help", false, "Show help options.");
-        options.addOption("knbvm", "knbvmtestadc", false, "Specify testing with knbvm");
+        // Add HashStore client options
+        Options options = addHashStoreOptions();
 
+        // Begin parsing options
         CommandLineParser parser = new DefaultParser();
         HelpFormatter formatter = new HelpFormatter();
         CommandLine cmd;
-        boolean knbvmTest = false;
-
         try {
             cmd = parser.parse(options, args);
 
             if (cmd.hasOption("h")) {
                 formatter.printHelp("CommandLineApp", options);
+
             } else {
                 if (cmd.hasOption("knbvm")) {
                     System.out.println(
@@ -70,6 +69,7 @@ public class Client {
             formatter.printHelp("CommandLineApp", options);
         }
 
+        boolean knbvmTest = false;
         if (knbvmTest) {
             // Get a HashStore
             initializeHashStore(storePath);
@@ -149,6 +149,68 @@ public class Client {
             }
         }
 
+    }
+
+    /**
+     * Create an options object to use with Apache Commons CLI library to manage command line
+     * options.
+     */
+    private static Options addHashStoreOptions() {
+        Options options = new Options();
+        options.addOption("h", "help", false, "Show help options.");
+        // Mandatory option
+        options.addOption("store", "storepath", true, "Path to HashStore.");
+        // HashStore creation options
+        options.addOption("chs", "createhashstore", false, "Create a HashStore.");
+        options.addOption("dp", "createhashstore", true, "Depth of HashStore.");
+        options.addOption("wp", "createhashstore", true, "Width of HashStore.");
+        options.addOption("ap", "createhashstore", true, "Algorithm of HashStore.");
+        options.addOption("nsp", "createhashstore", true, "Default metadata namespace");
+        // Public API options
+        options.addOption(
+            "getchecksum", "client_getchecksum", false,
+            "Get the hex digest of a data object in a HashStore"
+        );
+        options.addOption(
+            "storeobject", "client_storeobject", false, "Store object to a HashStore."
+        );
+        options.addOption(
+            "storemetadata", "client_storemetadata", false, "Store metadata to a HashStore"
+        );
+        options.addOption(
+            "retrieveobject", "client_retrieveobject", false, "Retrieve an object from a HashStore."
+        );
+        options.addOption(
+            "retrievemetadata", "client_retrievemetadata", false,
+            "Retrieve a metadata obj from a HashStore."
+        );
+        options.addOption(
+            "deleteobject", "client_deleteobject", false, "Delete an object from a HashStore."
+        );
+        options.addOption(
+            "deletemetadata", "client_deletemetadata", false,
+            "Delete a metadata obj from a HashStore."
+        );
+        options.addOption("pid", "pidguid", true, "PID or GUID of object.");
+        options.addOption("path", "filepath", true, "Path to object.");
+        options.addOption("algo", "objectalgo", true, "Algorithm to use in calculations.");
+        options.addOption("checksum", "obj_checksum", true, "Checksum of object.");
+        options.addOption(
+            "checksum_algo", "obj_checksum_algo", true, "Algorithm of checksum supplied."
+        );
+        options.addOption("size", "obj_size", true, "Size of object");
+        options.addOption("format_id", "metadata_format", true, "Metadata format_id/namespace");
+        // knbvm (test.arcticdata.io) options
+        options.addOption("knbvm", "knbvmtestadc", false, "Specify testing with knbvm.");
+        options.addOption("nobj", "numberofobj", false, "Number of objects to work with.");
+        options.addOption("sdir", "storedirectory", true, "Location of objects to convert.");
+        options.addOption("stype", "storetype", true, "Type of store 'objects' or 'metadata'");
+        options.addOption("sts", "storetohs", false, "Flag to store objs to a HashStore");
+        options.addOption(
+            "rav", "retandval", false, "Retrieve and validate objs from a HashStore."
+        );
+        options.addOption("dfs", "delfromhs", false, "Delete objs from a HashStore.");
+        return options;
     }
 
     private static void storeObjectsWithChecksum(List<Map<String, String>> resultObjList) {

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -66,7 +66,7 @@ public class Client {
                 String checksumAlgorithm = resultSet.getString("checksum_algorithm");
                 String formattedAlgo = formatAlgo(checksumAlgorithm);
 
-                Path setItemFilePath = Paths.get("/var/metacata/data/" + docid + "." + rev);
+                Path setItemFilePath = Paths.get("/var/metacat/data/" + docid + "." + rev);
                 System.out.println(setItemFilePath);
                 if (Files.exists(setItemFilePath)) {
                     System.out.println("File exists!");

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -115,7 +115,7 @@ public class Client {
             } catch (IllegalArgumentException iae) {
                 String errMsg = "Unexpected Error: " + iae.fillInStackTrace();
                 try {
-                    logExceptionToFile(guid, errMsg, "obj/store_errors/illegalargument");
+                    logExceptionToFile(guid, errMsg, "java/store_errors/illegalargument");
                 } catch (Exception e1) {
                     e1.printStackTrace();
                 }
@@ -123,7 +123,7 @@ public class Client {
             } catch (IOException ioe) {
                 String errMsg = "Unexpected Error: " + ioe.fillInStackTrace();
                 try {
-                    logExceptionToFile(guid, errMsg, "obj/store_errors/io");
+                    logExceptionToFile(guid, errMsg, "java/store_errors/io");
                 } catch (Exception e1) {
                     e1.printStackTrace();
                 }
@@ -131,7 +131,7 @@ public class Client {
             } catch (Exception e) {
                 String errMsg = "Unexpected Error: " + e.fillInStackTrace();
                 try {
-                    logExceptionToFile(guid, errMsg, "obj/store_errors/general");
+                    logExceptionToFile(guid, errMsg, "java/store_errors/general");
                 } catch (Exception e1) {
                     e1.printStackTrace();
                 }
@@ -161,7 +161,7 @@ public class Client {
                     String errMsg = "Obj retrieved (pid/guid): " + guid
                         + ". Checksums do not match, checksum from db: " + checksum
                         + ". Calculated digest: " + streamDigest + ". Algorithm: " + algorithm;
-                    logExceptionToFile(guid, errMsg, "obj/retrieve_errors/checksum_mismatch");
+                    logExceptionToFile(guid, errMsg, "java/retrieve_errors/checksum_mismatch");
                 } else {
                     System.out.println("Checksums match!");
                 }
@@ -169,7 +169,7 @@ public class Client {
             } catch (FileNotFoundException fnfe) {
                 String errMsg = "File not found: " + fnfe.fillInStackTrace();
                 try {
-                    logExceptionToFile(guid, errMsg, "obj/retrieve_errors/filenotfound");
+                    logExceptionToFile(guid, errMsg, "java/retrieve_errors/filenotfound");
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -177,7 +177,7 @@ public class Client {
             } catch (Exception e) {
                 String errMsg = "Unexpected Error: " + e.fillInStackTrace();
                 try {
-                    logExceptionToFile(guid, errMsg, "obj/retrieve_errors/general");
+                    logExceptionToFile(guid, errMsg, "java/retrieve_errors/general");
                 } catch (Exception e1) {
                     e1.printStackTrace();
                 }

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -31,10 +31,10 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class Client {
     private static HashStore hashStore;
+    private static Path storePath = Paths.get("/home/mok/testing/knbvm_testlog");
 
     public static void main(String[] args) throws Exception {
         // Get a HashStore
-        Path storePath = Paths.get("/home/mok/testing/knbvm_testlog");
         initializeHashStore(storePath);
 
         // Load metacat db yaml
@@ -161,7 +161,7 @@ public class Client {
                     String errMsg = "Obj retrieved (pid/guid): " + guid
                         + ". Checksums do not match, checksum from db: " + checksum
                         + ". Calculated digest: " + streamDigest + ". Algorithm: " + algorithm;
-                    logExceptionToFile(guid, errMsg, "obj/errors/checksum_mismatch");
+                    logExceptionToFile(guid, errMsg, "obj/retrieve_errors/checksum_mismatch");
                 } else {
                     System.out.println("Checksums match!");
                 }
@@ -169,7 +169,7 @@ public class Client {
             } catch (FileNotFoundException fnfe) {
                 String errMsg = "File not found: " + fnfe.fillInStackTrace();
                 try {
-                    logExceptionToFile(guid, errMsg, "obj/errors/filenotfound");
+                    logExceptionToFile(guid, errMsg, "obj/retrieve_errors/filenotfound");
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -177,7 +177,7 @@ public class Client {
             } catch (Exception e) {
                 String errMsg = "Unexpected Error: " + e.fillInStackTrace();
                 try {
-                    logExceptionToFile(guid, errMsg, "obj/errors/general");
+                    logExceptionToFile(guid, errMsg, "obj/retrieve_errors/general");
                 } catch (Exception e1) {
                     e1.printStackTrace();
                 }
@@ -189,7 +189,7 @@ public class Client {
     private static void logExceptionToFile(String guid, String errMsg, String directory)
         throws Exception {
         // Create directory to store the error files
-        Path errorDirectory = Paths.get("/home/mok/testing/knbvm_hashstore/java/" + directory);
+        Path errorDirectory = storePath.resolve(directory);
         Files.createDirectories(errorDirectory);
         Path objectErrorTxtFile = errorDirectory.resolve(guid + ".txt");
 

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -34,7 +34,7 @@ public class Client {
 
     public static void main(String[] args) throws Exception {
         // Get a HashStore
-        Path storePath = Paths.get("/home/mok/testing/knbvm_hashstore");
+        Path storePath = Paths.get("/home/mok/testing/knbvm_testlog");
         initializeHashStore(storePath);
 
         // Load metacat db yaml

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class Client {
     private static HashStore hashStore;
-    private static Path storePath = Paths.get("/home/mok/testing/knbvm_testlog");
+    private static Path storePath = Paths.get("/home/mok/testing/knbvm_hashstore");
 
     public static void main(String[] args) throws Exception {
         // Get a HashStore
@@ -57,7 +57,7 @@ public class Client {
             String sqlQuery = "SELECT identifier.guid, identifier.docid, identifier.rev,"
                 + " systemmetadata.object_format, systemmetadata.checksum,"
                 + " systemmetadata.checksum_algorithm FROM identifier INNER JOIN systemmetadata"
-                + " ON identifier.guid = systemmetadata.guid LIMIT 100000;";
+                + " ON identifier.guid = systemmetadata.guid;";
             ResultSet resultSet = statement.executeQuery(sqlQuery);
 
             // For each row, get guid, docid, rev, checksum and checksum_algorithm

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -34,7 +34,8 @@ public class Client {
         }
     }
 
-    public static void main() throws Exception {
+    public static void main(String[] args) throws Exception {
+
         try {
             Path storePath = Paths.get("/home/mok/testing/test_all");
 
@@ -99,7 +100,6 @@ public class Client {
         } catch (Exception e) {
             e.fillInStackTrace();
         }
-
 
     }
 

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -61,6 +61,7 @@ public class Client {
         try {
             System.out.println("Connecting to metacat db.");
             // Setup metacat db access
+            Class.forName("org.postgresql.Driver"); // Force driver to register itself
             Connection connection = DriverManager.getConnection(url, user, password);
             Statement statement = connection.createStatement();
             String sqlQuery = "SELECT identifier.guid, identifier.docid, identifier.rev,"

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -104,9 +104,14 @@ public class Client {
                     if (cmd.hasOption("dfs")) {
                         action = "dfs";
                     }
-                    String numObjects = cmd.getOptionValue("nobj");
+
                     String objType = cmd.getOptionValue("stype");
-                    testWithKnbvm(action, objType, numObjects);
+                    String originDirectory = cmd.getOptionValue("sdir");
+                    String numObjects = cmd.getOptionValue("nobj");
+                    ensureNotNull(objType, "-stype");
+                    ensureNotNull(originDirectory, "-sdir");
+                    ensureNotNull(action, "-sts, -rav, -dfs");
+                    testWithKnbvm(action, objType, originDirectory, numObjects);
 
                 } else if (cmd.hasOption("getchecksum")) {
                     String pid = cmd.getOptionValue("pid");
@@ -379,8 +384,9 @@ public class Client {
      *                   if null, will retrieve all rows.
      * @throws IOException Related to accessing config files or objects
      */
-    private static void testWithKnbvm(String actionFlag, String objType, String numObjects)
-        throws IOException {
+    private static void testWithKnbvm(
+        String actionFlag, String objType, String originDir, String numObjects
+    ) throws IOException {
         // Load metacat db yaml
         System.out.println("Loading metacat db yaml.");
         Path pgdbYaml = storePath.resolve("pgdb.yaml");
@@ -429,11 +435,12 @@ public class Client {
                         throw new IllegalArgumentException(errMsg);
                     }
                 }
-                Path setItemFilePath = Paths.get(
-                    "/var/metacat/" + objType + "/" + docid + "." + rev
-                );
+                Path setItemFilePath = Paths.get(originDir + "/" + docid + "." + rev);
 
                 if (Files.exists(setItemFilePath)) {
+                    System.out.println(
+                        "File exists (" + setItemFilePath + ")! Adding to resultObjList."
+                    );
                     Map<String, String> resultObj = new HashMap<>();
                     resultObj.put("pid", guid);
                     resultObj.put("algorithm", formattedChecksumAlgo);

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -1,0 +1,154 @@
+package org.dataone.hashstore;
+
+import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.xml.bind.DatatypeConverter;
+
+public class Client {
+    private static HashStore hashStore;
+
+    enum DefaultHashAlgorithms {
+        MD5("MD5"), SHA_1("SHA-1"), SHA_256("SHA-256"), SHA_384("SHA-384"), SHA_512("SHA-512");
+
+        final String algoName;
+
+        DefaultHashAlgorithms(String algo) {
+            algoName = algo;
+        }
+
+        public String getName() {
+            return algoName;
+        }
+    }
+
+    public static void main() throws Exception {
+        try {
+            Path storePath = Paths.get("/home/mok/testing/test_all");
+
+            // Initialize HashStore
+            String classPackage = "org.dataone.hashstore.filehashstore.FileHashStore";
+
+            Properties storeProperties = new Properties();
+            storeProperties.setProperty("storePath", storePath.toString());
+            storeProperties.setProperty("storeDepth", "3");
+            storeProperties.setProperty("storeWidth", "2");
+            storeProperties.setProperty("storeAlgorithm", "SHA-256");
+            storeProperties.setProperty("storeMetadataNamespace", "http://www.ns.test/v1");
+
+
+            // Get HashStore
+            hashStore = HashStoreFactory.getHashStore(classPackage, storeProperties);
+
+            // Get file names from `var/metacat/data`
+            // String originalObjDirectory = "/var/metacata/data";
+            // Path originalObjDirectoryPath = Paths.get(originalObjDirectory);
+            // File[] storePathFileList = storePath.toFile().listFiles();
+
+            Files.createDirectories(Paths.get("/home/mok/testing/test_all/douyamlcheck"));
+
+            // for (int i = 0; i < storePathFileList.length - 1; i++) {
+            for (int i = 0; i < 100; i++) {
+                String pid = "dou.test." + i;
+
+                try {
+                    InputStream pidObjStream = hashStore.retrieveObject(pid);
+                    Map<String, String> hexDigests = generateChecksums(pidObjStream);
+                    String yamlObjectString = getHexDigestsYamlString(
+                        hexDigests.get("MD5"), hexDigests.get("SHA-1"), hexDigests.get("SHA-256"),
+                        hexDigests.get("SHA-384"), hexDigests.get("SHA-512")
+                    );
+
+                    Path pidObjectYaml = Paths.get("/home/mok/testing/test_all/douyamlcheck")
+                        .resolve(pid + ".yaml");
+
+                    try (BufferedWriter writer = new BufferedWriter(
+                        new OutputStreamWriter(
+                            Files.newOutputStream(pidObjectYaml), StandardCharsets.UTF_8
+                        )
+                    )) {
+                        writer.write(yamlObjectString);
+
+                    } catch (Exception e) {
+                        e.fillInStackTrace();
+                    }
+
+                } catch (FileNotFoundException fnfe) {
+                    fnfe.fillInStackTrace();
+                } catch (IOException ioe) {
+                    ioe.fillInStackTrace();
+                } catch (IllegalArgumentException iae) {
+                    iae.fillInStackTrace();
+                } catch (NoSuchAlgorithmException nsae) {
+                    nsae.fillInStackTrace();
+                }
+            }
+
+        } catch (Exception e) {
+            e.fillInStackTrace();
+        }
+
+
+    }
+
+    private static String getHexDigestsYamlString(
+        String md5digest, String sha1digest, String sha256digest, String sha384digest,
+        String sha512digest
+    ) {
+        return String.format(
+            "md5digest:\n" + "- %s\n\n" + "sha1digest:\n" + "- %s\n\n" + "sha256digest:\n"
+                + "- %s\n\n" + "sha384digest:\n" + "- %s\n\n" + "sha512digest:\n" + "- %s\n\n",
+            md5digest, sha1digest, sha256digest, sha384digest, sha512digest
+        );
+    }
+
+    private static Map<String, String> generateChecksums(InputStream pidObjStream)
+        throws NoSuchAlgorithmException {
+        MessageDigest md5 = MessageDigest.getInstance(DefaultHashAlgorithms.MD5.getName());
+        MessageDigest sha1 = MessageDigest.getInstance(DefaultHashAlgorithms.SHA_1.getName());
+        MessageDigest sha256 = MessageDigest.getInstance(DefaultHashAlgorithms.SHA_256.getName());
+        MessageDigest sha384 = MessageDigest.getInstance(DefaultHashAlgorithms.SHA_384.getName());
+        MessageDigest sha512 = MessageDigest.getInstance(DefaultHashAlgorithms.SHA_512.getName());
+
+        try {
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = pidObjStream.read(buffer)) != -1) {
+                md5.update(buffer, 0, bytesRead);
+                sha1.update(buffer, 0, bytesRead);
+                sha256.update(buffer, 0, bytesRead);
+                sha384.update(buffer, 0, bytesRead);
+                sha512.update(buffer, 0, bytesRead);
+            }
+
+        } catch (Exception e) {
+            e.fillInStackTrace();
+        }
+
+        Map<String, String> hexDigests = new HashMap<>();
+        String md5Digest = DatatypeConverter.printHexBinary(md5.digest()).toLowerCase();
+        String sha1Digest = DatatypeConverter.printHexBinary(sha1.digest()).toLowerCase();
+        String sha256Digest = DatatypeConverter.printHexBinary(sha256.digest()).toLowerCase();
+        String sha384Digest = DatatypeConverter.printHexBinary(sha384.digest()).toLowerCase();
+        String sha512Digest = DatatypeConverter.printHexBinary(sha512.digest()).toLowerCase();
+        hexDigests.put(DefaultHashAlgorithms.MD5.getName(), md5Digest);
+        hexDigests.put(DefaultHashAlgorithms.SHA_1.getName(), sha1Digest);
+        hexDigests.put(DefaultHashAlgorithms.SHA_256.getName(), sha256Digest);
+        hexDigests.put(DefaultHashAlgorithms.SHA_384.getName(), sha384Digest);
+        hexDigests.put(DefaultHashAlgorithms.SHA_512.getName(), sha512Digest);
+
+        return hexDigests;
+    }
+}

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -127,22 +127,16 @@ public class Client {
      * @return Formatted algorithm value
      */
     private static String formatAlgo(String value) {
-        String checkedAlgorithm = "";
-        String[] SUPPORTED_HASH_ALGORITHMS = {"SHA-1", "SHA-256", "SHA-384", "SHA-512",
-            "SHA-512/224", "SHA-512/256"};
-
+        // Temporary solution to format algorithm values
+        // Query: SELECT DISTINCT checksum_algorithm FROM systemmetadata;
+        // Output: MD5, SHA-256, SHA256, SHA-1, SHA1
         String upperValue = value.toUpperCase();
-        if (upperValue.equals("MD2") || upperValue.equals("MD5")) {
-            checkedAlgorithm = upperValue;
+        String checkedAlgorithm = upperValue;
+        if (upperValue.equals("SHA1")) {
+            checkedAlgorithm = "SHA-1";
         }
-
-        String[] parts = upperValue.split("(?<=\\D)(?=\\d)");
-        String formattedAlgorithm = parts[0] + "-" + parts[1];
-        for (String element : SUPPORTED_HASH_ALGORITHMS) {
-            if (element.equals(formattedAlgorithm)) {
-                checkedAlgorithm = formattedAlgorithm;
-                break;
-            }
+        if (upperValue.equals("SHA256")) {
+            checkedAlgorithm = "SHA-256";
         }
         return checkedAlgorithm;
     }

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -114,12 +114,13 @@ public class Client {
                 hashStore.storeObject(objStream, guid, checksum, algorithm);
 
             } catch (PidObjectExistsException poee) {
-                String errMsg = "Unexpected Error: " + poee.fillInStackTrace();
-                try {
-                    logExceptionToFile(guid, errMsg, "java/store_errors/illegalargument");
-                } catch (Exception e1) {
-                    e1.printStackTrace();
-                }
+                poee.printStackTrace();
+                // String errMsg = "Unexpected Error: " + poee.fillInStackTrace();
+                // try {
+                //     logExceptionToFile(guid, errMsg, "java/store_errors/pidobjectexists");
+                // } catch (Exception e1) {
+                //     e1.printStackTrace();
+                // }
 
             } catch (IllegalArgumentException iae) {
                 String errMsg = "Unexpected Error: " + iae.fillInStackTrace();

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -112,6 +112,14 @@ public class Client {
                 System.out.println("Storing object for guid: " + guid);
                 hashStore.storeObject(objStream, guid, checksum, algorithm);
 
+            } catch (IllegalArgumentException iae) {
+                String errMsg = "Unexpected Error: " + iae.fillInStackTrace();
+                try {
+                    logExceptionToFile(guid, errMsg, "obj/store_errors/illegalargument");
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+
             } catch (IOException ioe) {
                 String errMsg = "Unexpected Error: " + ioe.fillInStackTrace();
                 try {

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -28,20 +28,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 public class Client {
     private static HashStore hashStore;
 
-    enum DefaultHashAlgorithms {
-        MD5("MD5"), SHA_1("SHA-1"), SHA_256("SHA-256"), SHA_384("SHA-384"), SHA_512("SHA-512");
-
-        final String algoName;
-
-        DefaultHashAlgorithms(String algo) {
-            algoName = algo;
-        }
-
-        public String getName() {
-            return algoName;
-        }
-    }
-
     public static void main(String[] args) throws Exception {
         // Get a HashStore
         Path storePath = Paths.get("/home/mok/testing/knbvm_hashstore");
@@ -136,7 +122,7 @@ public class Client {
     /**
      * Format an algorithm string value to be compatible with MessageDigest class
      * 
-     * @param value
+     * @param value Algorithm value to format
      * @return Formatted algorithm value
      */
     private static String formatAlgo(String value) {
@@ -154,6 +140,7 @@ public class Client {
         for (String element : SUPPORTED_HASH_ALGORITHMS) {
             if (element.equals(formattedAlgorithm)) {
                 checkedAlgorithm = formattedAlgorithm;
+                break;
             }
         }
         return checkedAlgorithm;
@@ -175,7 +162,6 @@ public class Client {
 
         // Get HashStore
         hashStore = HashStoreFactory.getHashStore(classPackage, storeProperties);
-        return;
     }
 
     /**

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -66,7 +66,7 @@ public class Client {
             String sqlQuery = "SELECT identifier.guid, identifier.docid, identifier.rev,"
                 + " systemmetadata.object_format, systemmetadata.checksum,"
                 + " systemmetadata.checksum_algorithm FROM identifier INNER JOIN systemmetadata"
-                + " ON identifier.guid = systemmetadata.guid LIMIT 10000";
+                + " ON identifier.guid = systemmetadata.guid LIMIT 10000;";
             ResultSet resultSet = statement.executeQuery(sqlQuery);
 
             // For each row, get guid, docid, rev, checksum and checksum_algorithm

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -52,7 +52,6 @@ public class Client {
         HelpFormatter formatter = new HelpFormatter();
         CommandLine cmd;
         try {
-            System.out.println("Parsing options");
             cmd = parser.parse(options, args);
 
             // First check if user is looking for help
@@ -126,7 +125,6 @@ public class Client {
                     ensureNotNull(pid, "-pid");
                     ensureNotNull(algo, "-algo");
                     String hexDigest = hashStore.getHexDigest(pid, algo);
-                    System.out.println("Hex Digest (pid: " + pid + ", algorithm: " + algo + "):");
                     System.out.println(hexDigest);
 
                 } else if (cmd.hasOption("storeobject")) {

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -57,7 +57,7 @@ public class Client {
             String sqlQuery = "SELECT identifier.guid, identifier.docid, identifier.rev,"
                 + " systemmetadata.object_format, systemmetadata.checksum,"
                 + " systemmetadata.checksum_algorithm FROM identifier INNER JOIN systemmetadata"
-                + " ON identifier.guid = systemmetadata.guid LIMIT 10000;";
+                + " ON identifier.guid = systemmetadata.guid;";
             ResultSet resultSet = statement.executeQuery(sqlQuery);
 
             // For each row, get guid, docid, rev, checksum and checksum_algorithm

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -93,6 +93,13 @@ public class Client {
                     System.out.println(
                         "HashStoreClient - Testing with KNBVM, checking pgdb.yaml & hashstore.yaml."
                     );
+                    Path pgdbYaml = storePath.resolve("pgdb.yaml");
+                    if (!Files.exists(pgdbYaml)) {
+                        String errMsg = "HashStoreClient - Missing pgdb.yaml at storePath ("
+                            + storePath + "), please manually create it with the following keys: "
+                            + "db_user, db_password, db_host, db_port, db_name";
+                        throw new FileNotFoundException(errMsg);
+                    }
 
                     String action = null;
                     if (cmd.hasOption("sts")) {
@@ -420,7 +427,6 @@ public class Client {
             // and create a List to loop over
             List<Map<String, String>> resultObjList = new ArrayList<>();
             while (resultSet.next()) {
-                System.out.println("Calling resultSet.next()");
                 String guid = resultSet.getString("guid");
                 String docid = resultSet.getString("docid");
                 int rev = resultSet.getInt("rev");

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -78,6 +78,7 @@ public class Client {
                 String formattedAlgo = formatAlgo(checksumAlgorithm);
 
                 // Retrieve object
+                System.out.println("Retrieving object for guid: " + guid);
                 InputStream objstream = hashStore.retrieveObject(guid);
 
                 // Get hex digest
@@ -106,6 +107,8 @@ public class Client {
                     } catch (Exception e) {
                         e.fillInStackTrace();
                     }
+                } else {
+                    System.out.println("Checksums match!");
                 }
             }
 

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -86,6 +86,7 @@ public class Client {
                 InputStream objstream = hashStore.retrieveObject(guid);
 
                 // Get hex digest
+                System.out.println("Calculating hex digest with algorithm: " + formattedAlgo);
                 String streamDigest = calculateHexDigest(objstream, formattedAlgo);
 
                 // If checksums don't match, write a .txt file

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -2,6 +2,7 @@ package org.dataone.hashstore;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
@@ -84,20 +85,20 @@ public class Client {
 
                         // If checksums don't match, write a .txt file
                         if (!streamDigest.equals(checksum)) {
-
-
                             String errMsg = "Obj retrieved (pid/guid): " + guid
                                 + ". Checksums do not match, checksum from db: " + checksum
                                 + ". Calculated digest: " + streamDigest + ". Algorithm: "
                                 + formattedAlgo;
-
-                            logExceptionToFile(guid, errMsg);
+                            logExceptionToFile(guid, errMsg, "checksum_mismatch");
                         } else {
                             System.out.println("Checksums match!");
                         }
+                    } catch (FileNotFoundException fnfe) {
+                        String errMsg = "File not found: " + fnfe.fillInStackTrace();
+                        logExceptionToFile(guid, errMsg, "filenotfound");
                     } catch (Exception e) {
                         String errMsg = "Unexpected Error: " + e.fillInStackTrace();
-                        logExceptionToFile(guid, errMsg);
+                        logExceptionToFile(guid, errMsg, "general");
                     }
                 }
             }
@@ -113,9 +114,12 @@ public class Client {
 
     }
 
-    private static void logExceptionToFile(String guid, String errMsg) throws Exception {
+    private static void logExceptionToFile(String guid, String errMsg, String directory)
+        throws Exception {
         // Create directory to store the error files
-        Path errorDirectory = Paths.get("/home/mok/testing/knbvm_hashstore/java/obj/errors");
+        Path errorDirectory = Paths.get(
+            "/home/mok/testing/knbvm_hashstore/java/obj/errors/" + directory
+        );
         Files.createDirectories(errorDirectory);
         Path objectErrorTxtFile = errorDirectory.resolve(guid + ".txt");
 

--- a/src/main/java/org/dataone/hashstore/Client.java
+++ b/src/main/java/org/dataone/hashstore/Client.java
@@ -67,8 +67,9 @@ public class Client {
                 String formattedAlgo = formatAlgo(checksumAlgorithm);
 
                 Path setItemFilePath = Paths.get("/var/metacata/data/" + docid + "." + rev);
+                System.out.println(setItemFilePath);
                 if (Files.exists(setItemFilePath)) {
-                    System.out.println("File exists at: " + setItemFilePath);
+                    System.out.println("File exists!");
 
                     // Retrieve object
                     System.out.println("Retrieving object for guid: " + guid);

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -96,6 +96,10 @@ public interface HashStore {
                 IllegalArgumentException, FileNotFoundException, InterruptedException,
                 NoSuchAlgorithmException;
 
+        String storeMetadata(InputStream metadata, String pid) throws IOException,
+                IllegalArgumentException, FileNotFoundException, InterruptedException,
+                NoSuchAlgorithmException;
+
         /**
          * The `retrieveObject` method retrieves an object from HashStore using a given persistent
          * identifier (pid).

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -59,6 +59,18 @@ public interface HashStore {
                 String checksumAlgorithm, long objSize
         ) throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException;
 
+        ObjectInfo storeObject(
+                InputStream object, String pid, String checksum, String checksumAlgorithm
+        ) throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException;
+
+        ObjectInfo storeObject(InputStream object, String pid, String additionalAlgorithm)
+                throws NoSuchAlgorithmException, IOException, PidObjectExistsException,
+                RuntimeException;
+
+        ObjectInfo storeObject(InputStream object, String pid, long objSize)
+                throws NoSuchAlgorithmException, IOException, PidObjectExistsException,
+                RuntimeException;
+
         /**
          * The `storeMetadata` method is responsible for adding/updating metadata (ex. `sysmeta`) to
          * the HashStore by using a given InputStream, a persistent identifier (`pid`) and metadata

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -670,6 +670,7 @@ public class FileHashStore implements HashStore {
     /**
      * Overload method for storeMetadata with default metadata namespace
      */
+    @Override
     public String storeMetadata(InputStream metadata, String pid) throws IOException,
         IllegalArgumentException, InterruptedException, NoSuchAlgorithmException {
         logFileHashStore.debug(

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -167,7 +167,7 @@ public class FileHashStore implements HashStore {
         } else {
             logFileHashStore.info(
                 "FileHashStore - 'hashstore.yaml' exists and has been verified."
-                    + "Initializing FileHashStore."
+                    + " Initializing FileHashStore."
             );
         }
     }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -269,13 +269,13 @@ public class FileHashStore implements HashStore {
      * @throws IOException If `hashstore.yaml` doesn't exist
      */
     protected HashMap<String, Object> loadHashStoreYaml(Path storePath) throws IOException {
-        Path hashstoreYaml = storePath.resolve("hashstore.yaml");
-        File hashStoreYaml = hashstoreYaml.toFile();
+        Path hashStoreYamlPath = storePath.resolve("hashstore.yaml");
+        File hashStoreYamlFile = hashStoreYamlPath.toFile();
         ObjectMapper om = new ObjectMapper(new YAMLFactory());
         HashMap<String, Object> hsProperties = new HashMap<>();
 
         try {
-            HashMap<?, ?> hashStoreYamlProperties = om.readValue(hashStoreYaml, HashMap.class);
+            HashMap<?, ?> hashStoreYamlProperties = om.readValue(hashStoreYamlFile, HashMap.class);
             String yamlStorePath = (String) hashStoreYamlProperties.get("store_path");
             hsProperties.put(HashStoreProperties.storePath.name(), Paths.get(yamlStorePath));
             hsProperties.put(

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -512,6 +512,7 @@ public class FileHashStore implements HashStore {
     /**
      * Overload method for storeObject with an additionalAlgorithm
      */
+    @Override
     public ObjectInfo storeObject(InputStream object, String pid, String additionalAlgorithm)
         throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException {
         logFileHashStore.debug(
@@ -534,6 +535,7 @@ public class FileHashStore implements HashStore {
     /**
      * Overload method for storeObject with just a checksum and checksumAlgorithm
      */
+    @Override
     public ObjectInfo storeObject(
         InputStream object, String pid, String checksum, String checksumAlgorithm
     ) throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException {
@@ -557,6 +559,7 @@ public class FileHashStore implements HashStore {
     /**
      * Overload method for storeObject with size of object to validate
      */
+    @Override
     public ObjectInfo storeObject(InputStream object, String pid, long objSize)
         throws NoSuchAlgorithmException, IOException, PidObjectExistsException, RuntimeException {
         logFileHashStore.debug(

--- a/src/test/java/org/dataone/hashstore/ClientTest.java
+++ b/src/test/java/org/dataone/hashstore/ClientTest.java
@@ -1,0 +1,432 @@
+package org.dataone.hashstore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+
+import org.dataone.hashstore.testdata.TestDataHarness;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ClientTest {
+    private static HashStore hashStore;
+    private static final TestDataHarness testData = new TestDataHarness();
+    private Properties hsProperties;
+
+    /**
+     * Temporary folder for tests to run in
+     */
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Before
+    public void getHashStore() {
+        String classPackage = "org.dataone.hashstore.filehashstore.FileHashStore";
+        Path rootDirectory = tempFolder.getRoot().toPath().resolve("metacat");
+
+        Properties storeProperties = new Properties();
+        storeProperties.setProperty("storePath", rootDirectory.toString());
+        storeProperties.setProperty("storeDepth", "3");
+        storeProperties.setProperty("storeWidth", "2");
+        storeProperties.setProperty("storeAlgorithm", "SHA-256");
+        storeProperties.setProperty(
+            "storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0"
+        );
+
+        try {
+            hsProperties = storeProperties;
+            hashStore = HashStoreFactory.getHashStore(classPackage, storeProperties);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("ClientTest - Exception encountered: " + e.getMessage());
+
+        }
+    }
+
+    /**
+     * Generates a hierarchical path by dividing a given digest into tokens of fixed width, and
+     * concatenating them with '/' as the delimiter.
+     *
+     * @param dirDepth integer to represent number of directories
+     * @param dirWidth width of each directory
+     * @param digest   value to shard
+     * @return String
+     */
+    protected String getHierarchicalPathString(int dirDepth, int dirWidth, String digest) {
+        List<String> tokens = new ArrayList<>();
+        int digestLength = digest.length();
+        for (int i = 0; i < dirDepth; i++) {
+            int start = i * dirWidth;
+            int end = Math.min((i + 1) * dirWidth, digestLength);
+            tokens.add(digest.substring(start, end));
+        }
+
+        if (dirDepth * dirWidth < digestLength) {
+            tokens.add(digest.substring(dirDepth * dirWidth));
+        }
+
+        List<String> stringArray = new ArrayList<>();
+        for (String str : tokens) {
+            if (!str.trim().isEmpty()) {
+                stringArray.add(str);
+            }
+        }
+        // stringShard
+        return String.join("/", stringArray);
+    }
+
+    /**
+     * Utility method to get absolute path of a given object and objType
+     * ("objects" or "metadata").
+     */
+    public Path getObjectAbsPath(String id, String objType) {
+        int shardDepth = Integer.parseInt(hsProperties.getProperty("storeDepth"));
+        int shardWidth = Integer.parseInt(hsProperties.getProperty("storeWidth"));
+        // Get relative path
+        String objCidShardString = this.getHierarchicalPathString(shardDepth, shardWidth, id);
+        // Get absolute path
+        Path storePath = Paths.get(hsProperties.getProperty("storePath"));
+        Path absPath = null;
+        if (objType.equals("object")) {
+            absPath = storePath.resolve("objects/" + objCidShardString);
+        }
+        if (objType.equals("metadata")) {
+            absPath = storePath.resolve("metadata/" + objCidShardString);
+        }
+        return absPath;
+    }
+
+    /**
+     * Test creating a HashStore through client.
+     */
+    @Test
+    public void client_createHashStore() throws Exception {
+        String optCreateHashstore = "-chs";
+        String optStore = "-store";
+        String optStorePath = tempFolder.getRoot() + "/metacat";
+        String optStoreDepth = "-dp";
+        String optStoreDepthValue = "3";
+        String optStoreWidth = "-wp";
+        String optStoreWidthValue = "2";
+        String optAlgo = "-ap";
+        String optAlgoValue = "SHA-256";
+        String optFormatId = "-nsp";
+        String optFormatIdValue = "http://ns.dataone.org/service/types/v2.0";
+        String[] args = {optCreateHashstore, optStore, optStorePath, optStoreDepth,
+            optStoreDepthValue, optStoreWidth, optStoreWidthValue, optAlgo, optAlgoValue,
+            optFormatId, optFormatIdValue};
+        Client.main(args);
+
+        Path storePath = Paths.get(optStorePath);
+        Path hashStoreObjectsPath = storePath.resolve("objects");
+        Path hashStoreMetadataPath = storePath.resolve("metadata");
+        Path hashStoreYaml = storePath.resolve("hashstore.yaml");
+        System.out.println(hashStoreYaml);
+        assertTrue(Files.exists(hashStoreObjectsPath));
+        assertTrue(Files.exists(hashStoreMetadataPath));
+        assertTrue(Files.exists(hashStoreYaml));
+    }
+
+    /**
+     * Test hashStore client stores objects.
+     */
+    @Test
+    public void client_storeObjects() throws Exception {
+        for (String pid : testData.pidList) {
+            // Redirect stdout to capture output
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(outputStream);
+            PrintStream old = System.out;
+            System.setOut(ps);
+
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            // Call client
+            String optStoreObject = "-storeobject";
+            String optStore = "-store";
+            String optStorePath = hsProperties.getProperty("storePath");
+            String optPath = "-path";
+            String optObjectPath = testDataFile.toString();
+            String optPid = "-pid";
+            String optPidValue = pid;
+            String[] args = {optStoreObject, optStore, optStorePath, optPath, optObjectPath, optPid,
+                optPidValue};
+            Client.main(args);
+
+            // Confirm object was stored
+            Path absPath = getObjectAbsPath(testData.pidData.get(pid).get("object_cid"), "object");
+            assertTrue(Files.exists(absPath));
+
+            // Put things back
+            System.out.flush();
+            System.setOut(old);
+
+            // Confirm client printed content
+            String pidStdOut = outputStream.toString();
+            assertFalse(pidStdOut.isEmpty());
+        }
+    }
+
+    /**
+     * Test hashStore client stores metadata.
+     */
+    @Test
+    public void client_storeMetadata() throws Exception {
+        for (String pid : testData.pidList) {
+            // Redirect stdout to capture output
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(outputStream);
+            PrintStream old = System.out;
+            System.setOut(ps);
+
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            // Call client
+            String optStoreMetadata = "-storemetadata";
+            String optStore = "-store";
+            String optStorePath = hsProperties.getProperty("storePath");
+            String optPath = "-path";
+            String optObjectPath = testDataFile.toString();
+            String optPid = "-pid";
+            String optPidValue = pid;
+            String optFormatId = "-format_id";
+            String optFormatIdValue = hsProperties.getProperty("storeMetadataNamespace");
+            String[] args = {optStoreMetadata, optStore, optStorePath, optPath, optObjectPath,
+                optPid, optPidValue, optFormatId, optFormatIdValue};
+            Client.main(args);
+
+            // Confirm metadata was stored
+            Path absPath = getObjectAbsPath(
+                testData.pidData.get(pid).get("metadata_cid"), "metadata"
+            );
+            assertTrue(Files.exists(absPath));
+
+            // Put things back
+            System.out.flush();
+            System.setOut(old);
+
+            // Confirm client printed content
+            String pidStdOut = outputStream.toString();
+            assertFalse(pidStdOut.isEmpty());
+        }
+    }
+
+    /**
+     * Test hashStore client retrieves objects.
+     */
+    @Test
+    public void client_retrieveObjects() throws Exception {
+        for (String pid : testData.pidList) {
+            // Redirect stdout to capture output
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(outputStream);
+            PrintStream old = System.out;
+            System.setOut(ps);
+
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            hashStore.storeObject(dataStream, pid, null, null, null, 0);
+
+            // Call client
+            String optRetrieveObject = "-retrieveobject";
+            String optStore = "-store";
+            String optStorePath = hsProperties.getProperty("storePath");
+            String optPid = "-pid";
+            String optPidValue = pid;
+            String[] args = {optRetrieveObject, optStore, optStorePath, optPid, optPidValue};
+            Client.main(args);
+
+            // Put things back
+            System.out.flush();
+            System.setOut(old);
+
+            // Confirm client printed content
+            String pidStdOut = outputStream.toString();
+            assertFalse(pidStdOut.isEmpty());
+        }
+    }
+
+    /**
+     * Test hashStore client retrieves objects.
+     */
+    @Test
+    public void client_retrieveMetadata() throws Exception {
+        for (String pid : testData.pidList) {
+            // Redirect stdout to capture output
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(outputStream);
+            PrintStream old = System.out;
+            System.setOut(ps);
+
+            String pidFormatted = pid.replace("/", "_");
+            Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
+            InputStream metadataStream = Files.newInputStream(testMetaDataFile);
+            hashStore.storeMetadata(metadataStream, pid);
+
+            // Call client
+            String optRetrieveMetadata = "-retrievemetadata";
+            String optStore = "-store";
+            String optStorePath = hsProperties.getProperty("storePath");
+            String optPid = "-pid";
+            String optPidValue = pid;
+            String optFormatId = "-format_id";
+            String optFormatIdValue = hsProperties.getProperty("storeMetadataNamespace");
+            String[] args = {optRetrieveMetadata, optStore, optStorePath, optPid, optPidValue,
+                optFormatId, optFormatIdValue};
+            Client.main(args);
+
+            // Put things back
+            System.out.flush();
+            System.setOut(old);
+
+            // Confirm client printed content
+            String pidStdOut = outputStream.toString();
+            assertFalse(pidStdOut.isEmpty());
+        }
+    }
+
+    /**
+     * Test hashStore client deletes objects.
+     */
+    @Test
+    public void client_deleteObjects() throws Exception {
+        for (String pid : testData.pidList) {
+            // Redirect stdout to capture output
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(outputStream);
+            PrintStream old = System.out;
+            System.setOut(ps);
+
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            hashStore.storeObject(dataStream, pid, null, null, null, 0);
+
+            // Call client
+            String optDeleteObject = "-deleteobject";
+            String optStore = "-store";
+            String optStorePath = hsProperties.getProperty("storePath");
+            String optPid = "-pid";
+            String optPidValue = pid;
+            String[] args = {optDeleteObject, optStore, optStorePath, optPid, optPidValue};
+            Client.main(args);
+
+            // Confirm object was deleted
+            Path absPath = getObjectAbsPath(testData.pidData.get(pid).get("object_cid"), "object");
+            assertFalse(Files.exists(absPath));
+
+            // Put things back
+            System.out.flush();
+            System.setOut(old);
+
+            // Confirm client printed content
+            String pidStdOut = outputStream.toString();
+            assertFalse(pidStdOut.isEmpty());
+        }
+    }
+
+    /**
+     * Test hashStore client retrieves objects.
+     */
+    @Test
+    public void client_deleteMetadata() throws Exception {
+        for (String pid : testData.pidList) {
+            // Redirect stdout to capture output
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(outputStream);
+            PrintStream old = System.out;
+            System.setOut(ps);
+
+            String pidFormatted = pid.replace("/", "_");
+            Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
+            InputStream metadataStream = Files.newInputStream(testMetaDataFile);
+            hashStore.storeMetadata(metadataStream, pid);
+
+            // Call client
+            String optDeleteMetadata = "-deletemetadata";
+            String optStore = "-store";
+            String optStorePath = hsProperties.getProperty("storePath");
+            String optPid = "-pid";
+            String optPidValue = pid;
+            String optFormatId = "-format_id";
+            String optFormatIdValue = hsProperties.getProperty("storeMetadataNamespace");
+            String[] args = {optDeleteMetadata, optStore, optStorePath, optPid, optPidValue,
+                optFormatId, optFormatIdValue};
+            Client.main(args);
+
+            // Confirm metadata was deleted
+            Path absPath = getObjectAbsPath(
+                testData.pidData.get(pid).get("metadata_cid"), "metadata"
+            );
+            assertFalse(Files.exists(absPath));
+
+            // Put things back
+            System.out.flush();
+            System.setOut(old);
+
+            // Confirm client printed content
+            String pidStdOut = outputStream.toString();
+            assertFalse(pidStdOut.isEmpty());
+        }
+    }
+
+    /**
+     * Test hashStore client returns hex digest of object.
+     */
+    @Test
+    public void client_getHexDigest() throws Exception {
+        for (String pid : testData.pidList) {
+            // Redirect stdout to capture output
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(outputStream);
+            PrintStream old = System.out;
+            System.setOut(ps);
+
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            hashStore.storeObject(dataStream, pid, null, null, null, 0);
+
+            // Call client
+            String optGetChecksum = "-getchecksum";
+            String optStore = "-store";
+            String optStorePath = hsProperties.getProperty("storePath");
+            String optPid = "-pid";
+            String optPidValue = pid;
+            String optAlgo = "-algo";
+            String optAlgoValue = "SHA-256";
+            String[] args = {optGetChecksum, optStore, optStorePath, optPid, optPidValue, optAlgo,
+                optAlgoValue};
+            Client.main(args);
+
+
+            String testDataChecksum = testData.pidData.get(pid).get("sha256");
+
+            // Put things back
+            System.out.flush();
+            System.setOut(old);
+
+            // Confirm hex digest matches
+            String pidStdOut = outputStream.toString();
+            assertEquals(testDataChecksum, pidStdOut.trim());
+        }
+    }
+}

--- a/src/test/java/org/dataone/hashstore/testdata/TestDataHarness.java
+++ b/src/test/java/org/dataone/hashstore/testdata/TestDataHarness.java
@@ -47,6 +47,10 @@ public class TestDataHarness {
                         "sha512-224", "107f9facb268471de250625440b6c8b7ff8296fbe5d89bed4a61fd35"
                 );
                 values1.put(
+                        "metadata_cid",
+                        "323e0799524cec4c7e14d31289cefd884b563b5c052f154a066de5ec1e477da7"
+                );
+                values1.put(
                         "metadata_sha256",
                         "158d7e55c36a810d7c14479c952a4d0b370f2b844808f2ea2b20d7df66768b04"
                 );
@@ -76,6 +80,10 @@ public class TestDataHarness {
                         "sha512-224", "7a2b22e36ced9e91cf8cdf6971897ec4ae21780e11d1c3903011af33"
                 );
                 values2.put(
+                        "metadata_cid",
+                        "ddf07952ef28efc099d10d8b682480f7d2da60015f5d8873b6e1ea75b4baf689"
+                );
+                values2.put(
                         "metadata_sha256",
                         "d87c386943ceaeba5644c52b23111e4f47972e6530df0e6f0f41964b25855b08"
                 );
@@ -103,6 +111,10 @@ public class TestDataHarness {
                 );
                 values3.put(
                         "sha512-224", "e1789a91c9df334fdf6ee5d295932ad96028c426a18b17016a627099"
+                );
+                values3.put(
+                        "metadata_cid",
+                        "9a2e08c666b728e6cbd04d247b9e556df3de5b2ca49f7c5a24868eb27cddbff2"
                 );
                 values3.put(
                         "metadata_sha256",


### PR DESCRIPTION
Summary of Changes:
- Add new java class `Client.java` and respective test class `ClientTest.java`
- Add new dependency to parse arguments from the command line `Apache Commons CLI`
- Revise `pom.xml` to allow packaging of Java project via mvn shade to execute Client code: `mvn clean package -Dmaven.test.skip=true`
- Add functionality to work with a HashStore directly through the java client
- Add functionality to query knbvm's metacat db and convert metacat data/documents into HashStore objects/metadata
    - Note: Users must manually create a `pgdb.yaml` file at store path in order to connect to the metacat db
- Updated `README.md` with instructions on how to use client app
- Revise comments and fix bugs in `FileHashStore` and `HashStore` for method override options