### PR TITLE
Feature-60: Rename `refs` subdirectories

### DIFF
--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -161,8 +161,8 @@ public class FileHashStore implements HashStore {
         OBJECT_TMP_FILE_DIRECTORY = OBJECT_STORE_DIRECTORY.resolve("tmp");
         METADATA_TMP_FILE_DIRECTORY = METADATA_STORE_DIRECTORY.resolve("tmp");
         REFS_TMP_FILE_DIRECTORY = REFS_STORE_DIRECTORY.resolve("tmp");
-        REFS_PID_FILE_DIRECTORY = REFS_STORE_DIRECTORY.resolve(HashStoreIdTypes.pid.getName());
-        REFS_CID_FILE_DIRECTORY = REFS_STORE_DIRECTORY.resolve(HashStoreIdTypes.cid.getName());
+        REFS_PID_FILE_DIRECTORY = REFS_STORE_DIRECTORY.resolve("pids");
+        REFS_CID_FILE_DIRECTORY = REFS_STORE_DIRECTORY.resolve("cids");
 
         try {
             // Physically create object & metadata store and tmp directories

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -758,7 +758,8 @@ public class FileHashStoreInterfaceTest {
 
         // Confirm that 50 pid refs file exists
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
-        List<Path> pidRefFiles = FileHashStoreUtility.getFilesFromDir(storePath.resolve("refs/pid"));
+        List<Path> pidRefFiles = FileHashStoreUtility.getFilesFromDir(storePath.resolve("refs"
+                                                                                            + "/pids"));
         assertEquals(50, pidRefFiles.size());
     }
 
@@ -1710,9 +1711,11 @@ public class FileHashStoreInterfaceTest {
         List<Path> objects = FileHashStoreUtility.getFilesFromDir(storePath.resolve("objects"));
         assertEquals(0, objects.size());
         // Check that no refs files exist
-        List<Path> pidRefFiles = FileHashStoreUtility.getFilesFromDir(storePath.resolve("refs/pid"));
+        List<Path> pidRefFiles = FileHashStoreUtility.getFilesFromDir(storePath.resolve("refs"
+                                                                                            + "/pids"));
         assertEquals(0, pidRefFiles.size());
-        List<Path> cidRefFiles = FileHashStoreUtility.getFilesFromDir(storePath.resolve("refs/cid"));
+        List<Path> cidRefFiles = FileHashStoreUtility.getFilesFromDir(storePath.resolve("refs"
+                                                                                            + "/cids"));
         assertEquals(0, cidRefFiles.size());
     }
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -1087,7 +1087,8 @@ public class FileHashStoreProtectedTest {
             String metadataPidHashSharded = FileHashStoreUtility.getHierarchicalPathString(
                 storeDepth, storeWidth, metadataPidHash
             );
-            Path calculatedPidRefsRealPath = storePath.resolve("refs/pid").resolve(metadataPidHashSharded);
+            Path calculatedPidRefsRealPath =
+                storePath.resolve("refs/pids").resolve(metadataPidHashSharded);
 
             Path expectedPidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
 
@@ -1120,7 +1121,7 @@ public class FileHashStoreProtectedTest {
             String objShardString = FileHashStoreUtility.getHierarchicalPathString(
                 storeDepth, storeWidth, cid
             );
-            Path calculatedCidRefsRealPath = storePath.resolve("refs/cid").resolve(objShardString);
+            Path calculatedCidRefsRealPath = storePath.resolve("refs/cids").resolve(objShardString);
 
             Path expectedCidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -277,9 +277,9 @@ public class FileHashStorePublicTest {
         assertTrue(Files.isDirectory(refsPath));
         Path refsTmpPath = rootDirectory.resolve("refs/tmp");
         assertTrue(Files.isDirectory(refsTmpPath));
-        Path refsPidPath = rootDirectory.resolve("refs/pid");
+        Path refsPidPath = rootDirectory.resolve("refs/pids");
         assertTrue(Files.isDirectory(refsPidPath));
-        Path refsCidPath = rootDirectory.resolve("refs/cid");
+        Path refsCidPath = rootDirectory.resolve("refs/cids");
         assertTrue(Files.isDirectory(refsCidPath));
     }
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -80,9 +80,9 @@ public class FileHashStoreReferencesTest {
         fileHashStore.tagObject(pid, cid);
 
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
-        File[] pidRefsFiles = storePath.resolve("refs/pid").toFile().listFiles();
+        File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();
         assertEquals(1, pidRefsFiles.length);
-        File[] cidRefsFiles = storePath.resolve("refs/cid").toFile().listFiles();
+        File[] cidRefsFiles = storePath.resolve("refs/cids").toFile().listFiles();
         assertEquals(1, cidRefsFiles.length);
     }
 
@@ -132,9 +132,9 @@ public class FileHashStoreReferencesTest {
         fileHashStore.tagObject(pid, cid);
         // Confirm that there is only 1 of each refs file
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
-        File[] pidRefsFiles = storePath.resolve("refs/pid").toFile().listFiles();
+        File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();
         assertEquals(1, pidRefsFiles.length);
-        File[] cidRefsFiles = storePath.resolve("refs/cid").toFile().listFiles();
+        File[] cidRefsFiles = storePath.resolve("refs/cids").toFile().listFiles();
         assertEquals(1, cidRefsFiles.length);
     }
 
@@ -181,9 +181,9 @@ public class FileHashStoreReferencesTest {
         fileHashStore.tagObject(pid, cid);
         // There should only be 1 of each refs file
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
-        File[] pidRefsFiles = storePath.resolve("refs/pid").toFile().listFiles();
+        File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();
         assertEquals(1, pidRefsFiles.length);
-        File[] cidRefsFiles = storePath.resolve("refs/cid").toFile().listFiles();
+        File[] cidRefsFiles = storePath.resolve("refs/cids").toFile().listFiles();
         assertEquals(1, cidRefsFiles.length);
     }
 
@@ -202,9 +202,9 @@ public class FileHashStoreReferencesTest {
         fileHashStore.tagObject(pid, cid);
         // Confirm that there is only 1 of each refs file
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
-        File[] pidRefsFiles = storePath.resolve("refs/pid").toFile().listFiles();
+        File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();
         assertEquals(1, pidRefsFiles.length);
-        File[] cidRefsFiles = storePath.resolve("refs/cid").toFile().listFiles();
+        File[] cidRefsFiles = storePath.resolve("refs/cids").toFile().listFiles();
         assertEquals(1, cidRefsFiles.length);
     }
 
@@ -236,9 +236,9 @@ public class FileHashStoreReferencesTest {
 
         // There should be 2 pid refs file, and 1 cid refs file
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
-        File[] pidRefsFiles = storePath.resolve("refs/pid").toFile().listFiles();
+        File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();
         assertEquals(2, pidRefsFiles.length);
-        File[] cidRefsFiles = storePath.resolve("refs/cid").toFile().listFiles();
+        File[] cidRefsFiles = storePath.resolve("refs/cids").toFile().listFiles();
         assertEquals(1, cidRefsFiles.length);
     }
 


### PR DESCRIPTION
Summary of Changes:
- Renamed `refs/pid/` and `refs/cid/` directories to `refs/pids/` and `refs/cids/
- Updated junit tests