### PR TITLE
Feature-61: Metadata API Thread Safety

### DIFF
--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -292,9 +292,10 @@ public interface HashStore {
          * @throws IOException              I/O error when deleting metadata or empty directories
          * @throws NoSuchAlgorithmException When algorithm used to calculate object address is not
          *                                  supported
+         * @throws InterruptedException Issue with synchronization on metadta doc
          */
         public void deleteMetadata(String pid, String formatId) throws IllegalArgumentException,
-                IOException, NoSuchAlgorithmException;
+                IOException, NoSuchAlgorithmException, InterruptedException;
 
         /**
          * Deletes all metadata related for the given 'pid' from HashStore
@@ -304,9 +305,10 @@ public interface HashStore {
          * @throws IOException              I/O error when deleting metadata or empty directories
          * @throws NoSuchAlgorithmException When algorithm used to calculate object address is not
          *                                  supported
+         * @throws InterruptedException Issue with synchronization on metadta doc
          */
         public void deleteMetadata(String pid) throws IllegalArgumentException, IOException,
-                NoSuchAlgorithmException;
+                NoSuchAlgorithmException, InterruptedException;
 
         /**
          * Calculates the hex digest of an object that exists in HashStore using a given persistent

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -292,7 +292,7 @@ public interface HashStore {
          * @throws IOException              I/O error when deleting metadata or empty directories
          * @throws NoSuchAlgorithmException When algorithm used to calculate object address is not
          *                                  supported
-         * @throws InterruptedException Issue with synchronization on metadta doc
+         * @throws InterruptedException Issue with synchronization on metadata doc
          */
         public void deleteMetadata(String pid, String formatId) throws IllegalArgumentException,
                 IOException, NoSuchAlgorithmException, InterruptedException;
@@ -305,7 +305,7 @@ public interface HashStore {
          * @throws IOException              I/O error when deleting metadata or empty directories
          * @throws NoSuchAlgorithmException When algorithm used to calculate object address is not
          *                                  supported
-         * @throws InterruptedException Issue with synchronization on metadta doc
+         * @throws InterruptedException Issue with synchronization on metadata doc
          */
         public void deleteMetadata(String pid) throws IllegalArgumentException, IOException,
                 NoSuchAlgorithmException, InterruptedException;

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1130,11 +1130,6 @@ public class FileHashStore implements HashStore {
                 String pidRelativePath =
                     FileHashStoreUtility.getHierarchicalPathString(DIRECTORY_DEPTH, DIRECTORY_WIDTH,
                                                                    pidHexDigest);
-                Path expectedPidMetadataDirectory =
-                    METADATA_STORE_DIRECTORY.resolve(pidRelativePath);
-                // Add all metadata doc paths to a List to iterate over below
-                List<Path> metadataDocPaths =
-                    FileHashStoreUtility.getFilesFromDir(expectedPidMetadataDirectory);
 
                 try {
                     // Before we begin deletion process, we look for the `cid` by calling
@@ -1179,11 +1174,6 @@ public class FileHashStore implements HashStore {
                         Path absPidRefsPath =
                             getExpectedPath(pid, "refs", HashStoreIdTypes.pid.getName());
 
-                        // Rename metadata documents to prepare for deletion
-                        for (Path metadataDoc : metadataDocPaths) {
-                            deleteList.add(FileHashStoreUtility.renamePathForDeletion(metadataDoc));
-                        }
-
                         // Rename pid refs file to prepare for deletion
                         deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
                         // Remove pid from cid refs file
@@ -1204,6 +1194,8 @@ public class FileHashStore implements HashStore {
                         }
                         // Delete all related/relevant items with the least amount of delay
                         FileHashStoreUtility.deleteListItems(deleteList);
+                        // Remove metadata files
+                        deleteMetadata(pid);
                         logFileHashStore.info(
                             "FileHashStore.deleteObject - File and references deleted for: " + pid
                                 + " with object address: " + objRealPath);
@@ -1228,13 +1220,10 @@ public class FileHashStore implements HashStore {
                     Path absPidRefsPath =
                         getExpectedPath(pid, "refs", HashStoreIdTypes.pid.getName());
                     deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
-
-                    // Rename metadata documents for deletion
-                    for (Path metadataDoc : metadataDocPaths) {
-                        deleteList.add(FileHashStoreUtility.renamePathForDeletion(metadataDoc));
-                    }
-
+                    // Delete items
                     FileHashStoreUtility.deleteListItems(deleteList);
+                    // Remove metadata files
+                    deleteMetadata(pid);
                     String warnMsg =
                         "FileHashStore.deleteObject - Cid refs file does not exist for pid: " + pid
                             + ". Deleted orphan pid refs file and metadata.";
@@ -1283,14 +1272,10 @@ public class FileHashStore implements HashStore {
                             deleteList.add(
                                 FileHashStoreUtility.renamePathForDeletion(absCidRefsPath));
                         }
-
-                        // Rename metadata documents for deletion
-                        for (Path metadataDoc : metadataDocPaths) {
-                            deleteList.add(FileHashStoreUtility.renamePathForDeletion(metadataDoc));
-                        }
-
                         // Delete items
                         FileHashStoreUtility.deleteListItems(deleteList);
+                        // Remove metadata files
+                        deleteMetadata(pid);
                         String warnMsg = "FileHashStore.deleteObject - Object with cid: " + cidRead
                             + " does not exist, but pid and cid reference file found for pid: "
                             + pid + ". Deleted pid and cid ref files and metadata.";
@@ -1314,14 +1299,10 @@ public class FileHashStore implements HashStore {
                     Path absPidRefsPath =
                         getExpectedPath(pid, "refs", HashStoreIdTypes.pid.getName());
                     deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
-
-                    // Rename metadata documents for deletion
-                    for (Path metadataDoc : metadataDocPaths) {
-                        deleteList.add(FileHashStoreUtility.renamePathForDeletion(metadataDoc));
-                    }
-
                     // Delete items
                     FileHashStoreUtility.deleteListItems(deleteList);
+                    // Remove metadata files
+                    deleteMetadata(pid);
                     String warnMsg =
                         "FileHashStore.deleteObject - Pid not found in expected cid refs file for"
                             + " pid: " + pid + ". Deleted orphan pid refs file and metadata.";


### PR DESCRIPTION
**Summary of Changes:**
- Storing and deleting metadata is now synchronized based on the doc name (hash of the `pid+formatId`)
- `deleteObject` now calls `deleteMetadata` instead of retrieving the document names from the metadata directory