### PR TITLE
Feature-65: `verifyObject` Update

### DIFF
--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -5,10 +5,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
 
+import org.dataone.hashstore.exceptions.NonMatchingChecksumException;
+import org.dataone.hashstore.exceptions.NonMatchingObjSizeException;
 import org.dataone.hashstore.exceptions.OrphanPidRefsFileException;
 import org.dataone.hashstore.exceptions.OrphanRefsFilesException;
 import org.dataone.hashstore.exceptions.PidNotFoundInCidRefsFileException;
 import org.dataone.hashstore.exceptions.PidRefsFileExistsException;
+import org.dataone.hashstore.exceptions.UnsupportedHashAlgorithmException;
 
 /**
  * HashStore is a content-addressable file management system that utilizes the content identifier of
@@ -143,16 +146,19 @@ public interface HashStore {
         /**
          * Confirms that an ObjectMetadata's content is equal to the given values. If it is not
          * equal, it will return False - otherwise True.
-         * 
+         *
          * @param objectInfo        ObjectMetadata object with values
          * @param checksum          Value of checksum to validate against
          * @param checksumAlgorithm Algorithm of checksum submitted
          * @param objSize           Expected size of object to validate after storing
-         * @throws IllegalArgumentException An expected value does not match
+         * @throws NonMatchingObjSizeException       Given size =/= objMeta size value
+         * @throws NonMatchingChecksumException      Given checksum =/= objMeta checksum value
+         * @throws UnsupportedHashAlgorithmException Given algo is not found or supported
          */
-        public boolean verifyObject(
+        public void verifyObject(
                 ObjectMetadata objectInfo, String checksum, String checksumAlgorithm, long objSize
-        ) throws IllegalArgumentException;
+        ) throws NonMatchingObjSizeException, NonMatchingChecksumException,
+            UnsupportedHashAlgorithmException;
 
         /**
          * Checks whether an object referenced by a pid exists and returns the content identifier.

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -154,11 +154,12 @@ public interface HashStore {
          * @throws NonMatchingObjSizeException       Given size =/= objMeta size value
          * @throws NonMatchingChecksumException      Given checksum =/= objMeta checksum value
          * @throws UnsupportedHashAlgorithmException Given algo is not found or supported
+         * @throws IOException Issue with recalculating supported algo for checksum not found
          */
         public void verifyObject(
                 ObjectMetadata objectInfo, String checksum, String checksumAlgorithm, long objSize
         ) throws NonMatchingObjSizeException, NonMatchingChecksumException,
-            UnsupportedHashAlgorithmException;
+            UnsupportedHashAlgorithmException, IOException;
 
         /**
          * Checks whether an object referenced by a pid exists and returns the content identifier.

--- a/src/main/java/org/dataone/hashstore/exceptions/NonMatchingChecksumException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/NonMatchingChecksumException.java
@@ -7,4 +7,5 @@ public class NonMatchingChecksumException extends IOException {
     public NonMatchingChecksumException(String message) {
         super(message);
     }
+
 }

--- a/src/main/java/org/dataone/hashstore/exceptions/NonMatchingChecksumException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/NonMatchingChecksumException.java
@@ -1,0 +1,10 @@
+package org.dataone.hashstore.exceptions;
+
+import java.io.IOException;
+
+public class NonMatchingChecksumException extends IOException {
+
+    public NonMatchingChecksumException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/dataone/hashstore/exceptions/NonMatchingObjSizeException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/NonMatchingObjSizeException.java
@@ -1,0 +1,12 @@
+package org.dataone.hashstore.exceptions;
+
+import java.io.IOException;
+
+public class NonMatchingObjSizeException extends IOException {
+
+    public NonMatchingObjSizeException(String message) {
+        super(message);
+    }
+
+}
+

--- a/src/main/java/org/dataone/hashstore/exceptions/UnsupportedHashAlgorithmException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/UnsupportedHashAlgorithmException.java
@@ -1,0 +1,8 @@
+package org.dataone.hashstore.exceptions;
+
+public class UnsupportedHashAlgorithmException extends IllegalArgumentException {
+
+    public UnsupportedHashAlgorithmException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/dataone/hashstore/exceptions/UnsupportedHashAlgorithmException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/UnsupportedHashAlgorithmException.java
@@ -5,4 +5,5 @@ public class UnsupportedHashAlgorithmException extends IllegalArgumentException 
     public UnsupportedHashAlgorithmException(String message) {
         super(message);
     }
+
 }

--- a/src/test/java/org/dataone/hashstore/HashStoreClientTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreClientTest.java
@@ -258,6 +258,7 @@ public class HashStoreClientTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
             InputStream dataStream = Files.newInputStream(testDataFile);
             hashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Call client
             String optRetrieveObject = "-retrieveobject";
@@ -294,6 +295,7 @@ public class HashStoreClientTest {
             Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             hashStore.storeMetadata(metadataStream, pid);
+            metadataStream.close();
 
             // Call client
             String optRetrieveMetadata = "-retrievemetadata";
@@ -333,6 +335,7 @@ public class HashStoreClientTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
             InputStream dataStream = Files.newInputStream(testDataFile);
             hashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Call client
             String optDeleteObject = "-deleteobject";
@@ -373,6 +376,7 @@ public class HashStoreClientTest {
             Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             hashStore.storeMetadata(metadataStream, pid);
+            metadataStream.close();
 
             // Call client
             String optDeleteMetadata = "-deletemetadata";
@@ -418,6 +422,7 @@ public class HashStoreClientTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
             InputStream dataStream = Files.newInputStream(testDataFile);
             hashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Call client
             String optGetChecksum = "-getchecksum";
@@ -460,6 +465,7 @@ public class HashStoreClientTest {
             Path testDataFile = testData.getTestFile(pidFormatted);
             InputStream dataStream = Files.newInputStream(testDataFile);
             hashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Call client
             String optFindObject = "-findobject";

--- a/src/test/java/org/dataone/hashstore/HashStoreRunnable.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreRunnable.java
@@ -5,6 +5,7 @@ import org.apache.commons.logging.LogFactory;
 import org.dataone.hashstore.exceptions.HashStoreServiceException;
 import org.dataone.hashstore.filehashstore.FileHashStoreUtility;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -52,6 +53,7 @@ public class HashStoreRunnable implements Runnable {
                     } catch (Exception e) {
                         throw new HashStoreServiceException(e.getMessage());
                     }
+                    objStream.close();
                     break;
                 case deleteObject:
                     try {
@@ -63,6 +65,8 @@ public class HashStoreRunnable implements Runnable {
             }
         } catch (HashStoreServiceException hse) {
             logHssr.error("HashStoreServiceRequest - Error: " + hse.getMessage());
+        } catch (IOException ioe) {
+            logHssr.error("HashStoreServiceRequest - Error: " + ioe.getMessage());
         }
     }
 }

--- a/src/test/java/org/dataone/hashstore/HashStoreTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreTest.java
@@ -128,6 +128,7 @@ public class HashStoreTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = hashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Check id (sha-256 hex digest of the ab_id, aka object_cid)
             String objContentId = testData.pidData.get(pid).get("sha256");

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -110,6 +110,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
 
             // Check id (content identifier based on the store algorithm)
             String objectCid = testData.pidData.get(pid).get("sha256");
@@ -131,6 +132,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
 
             // Check the object size
             long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
@@ -151,6 +153,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
 
             Map<String, String> hexDigests = objInfo.getHexDigests();
 
@@ -191,6 +194,7 @@ public class FileHashStoreInterfaceTest {
 
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 fileHashStore.storeObject(dataStream, null, null, null, null, -1);
+                dataStream.close();
             });
         }
     }
@@ -207,6 +211,7 @@ public class FileHashStoreInterfaceTest {
 
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 fileHashStore.storeObject(dataStream, "", null, null, null, -1);
+                dataStream.close();
             });
         }
     }
@@ -223,6 +228,7 @@ public class FileHashStoreInterfaceTest {
 
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 fileHashStore.storeObject(dataStream, pid, null, null, null, 0);
+                dataStream.close();
             });
         }
     }
@@ -243,6 +249,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, md2, "MD2", objectSize
             );
+            dataStream.close();
 
             Map<String, String> hexDigests = objInfo.getHexDigests();
 
@@ -263,6 +270,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, md2, "MD2");
+            dataStream.close();
 
             Map<String, String> hexDigests = objInfo.getHexDigests();
 
@@ -283,6 +291,7 @@ public class FileHashStoreInterfaceTest {
             long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, objectSize);
+            dataStream.close();
 
             assertEquals(objectSize, objInfo.getSize());
         }
@@ -300,6 +309,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
 
             Map<String, String> hexDigests = objInfo.getHexDigests();
             String defaultStoreAlgorithm = fhsProperties.getProperty("storeAlgorithm");
@@ -327,6 +337,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, "MD2");
+            dataStream.close();
 
             Map<String, String> hexDigests = objInfo.getHexDigests();
 
@@ -349,6 +360,7 @@ public class FileHashStoreInterfaceTest {
 
         InputStream dataStream = Files.newInputStream(testDataFile);
         fileHashStore.storeObject(dataStream, pid, null, checksumCorrect, "SHA-256", -1);
+        dataStream.close();
 
         Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
         assertTrue(Files.exists(objCidAbsPath));
@@ -367,6 +379,7 @@ public class FileHashStoreInterfaceTest {
 
         InputStream dataStream = Files.newInputStream(testDataFile);
         fileHashStore.storeObject(dataStream, pid, "MD2", null, null, -1);
+        dataStream.close();
 
         String md2 = testData.pidData.get(pid).get("md2");
         assertEquals(checksumCorrect, md2);
@@ -387,6 +400,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, checksumIncorrect, "SHA-256", -1);
+            dataStream.close();
         });
     }
 
@@ -404,6 +418,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, checksumEmpty, "MD2", -1);
+            dataStream.close();
         });
     }
 
@@ -419,6 +434,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, null, "SHA-512/224", -1);
+            dataStream.close();
         });
     }
 
@@ -436,6 +452,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, objectSize
             );
+            dataStream.close();
 
             // Check id (sha-256 hex digest of the ab_id (pid))
             assertEquals(objectSize, objInfo.getSize());
@@ -456,6 +473,7 @@ public class FileHashStoreInterfaceTest {
                 ObjectMetadata objInfo = fileHashStore.storeObject(
                     dataStream, pid, null, null, null, 1000
                 );
+                dataStream.close();
 
                 // Check id (sha-256 hex digest of the ab_id (pid))
                 long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
@@ -476,6 +494,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, "SM2", null, null, -1);
+            dataStream.close();
         });
     }
 
@@ -491,12 +510,14 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             String pidTwo = pid + ".test";
             InputStream dataStreamDup = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStreamDup, pidTwo, null, null, null, -1
             );
+            dataStreamDup.close();
 
             String cid = objInfo.getCid();
             Path absCidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
@@ -533,6 +554,7 @@ public class FileHashStoreInterfaceTest {
         InputStream dataStream = Files.newInputStream(testFilePath);
         String pid = "dou.sparsefile.1";
         fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+        dataStream.close();
 
         Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
         assertTrue(Files.exists(objCidAbsPath));
@@ -567,6 +589,7 @@ public class FileHashStoreInterfaceTest {
                 InputStream dataStream = Files.newInputStream(testFilePath);
                 String pid = "dou.sparsefile.1";
                 fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+                dataStream.close();
             } catch (IOException | NoSuchAlgorithmException | InterruptedException ioe) {
                 ioe.printStackTrace();
             }
@@ -611,6 +634,7 @@ public class FileHashStoreInterfaceTest {
                 ObjectMetadata objInfo = fileHashStore.storeObject(
                     dataStream, pid, null, null, null, -1
                 );
+                dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
                     Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -631,6 +655,7 @@ public class FileHashStoreInterfaceTest {
                 ObjectMetadata objInfo = fileHashStore.storeObject(
                     dataStream, pid, null, null, null, -1
                 );
+                dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
                     Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -651,6 +676,7 @@ public class FileHashStoreInterfaceTest {
                 ObjectMetadata objInfo = fileHashStore.storeObject(
                     dataStream, pid, null, null, null, -1
                 );
+                dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
                     Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -671,6 +697,7 @@ public class FileHashStoreInterfaceTest {
                 ObjectMetadata objInfo = fileHashStore.storeObject(
                     dataStream, pid, null, null, null, -1
                 );
+                dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
                     Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -691,6 +718,7 @@ public class FileHashStoreInterfaceTest {
                 ObjectMetadata objInfo = fileHashStore.storeObject(
                     dataStream, pid, null, null, null, -1
                 );
+                dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
                     Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -778,6 +806,7 @@ public class FileHashStoreInterfaceTest {
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             String testFormatId = "https://test.arcticdata.io/ns";
             String metadataPath = fileHashStore.storeMetadata(metadataStream, pid, testFormatId);
+            metadataStream.close();
 
             // Calculate absolute path
             Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
@@ -802,6 +831,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             String metadataPath = fileHashStore.storeMetadata(metadataStream, pid);
+            metadataStream.close();
 
             // Calculate absolute path
             String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
@@ -827,6 +857,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             fileHashStore.storeMetadata(metadataStream, pid);
+            metadataStream.close();
 
             String storeAlgo = fhsProperties.getProperty("storeAlgorithm");
             int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
@@ -857,7 +888,11 @@ public class FileHashStoreInterfaceTest {
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             String testFormatId = "https://test.arcticdata.io/ns";
             String metadataPath = fileHashStore.storeMetadata(metadataStream, pid, testFormatId);
-            String metadataDefaultPath = fileHashStore.storeMetadata(metadataStream, pid);
+            metadataStream.close();
+
+            InputStream metadataStreamDup = Files.newInputStream(testMetaDataFile);
+            String metadataDefaultPath = fileHashStore.storeMetadata(metadataStreamDup, pid);
+            metadataStreamDup.close();
 
             // Calculate absolute path
             Path metadataTestFormatIdExpectedPath = fileHashStore.getExpectedPath(
@@ -888,6 +923,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             String metadataPath = fileHashStore.storeMetadata(metadataStream, pid, null);
+            metadataStream.close();
 
             long writtenMetadataFile = Files.size(testMetaDataFile);
             long originalMetadataFie = Files.size(Paths.get(metadataPath));
@@ -922,6 +958,7 @@ public class FileHashStoreInterfaceTest {
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
 
                 fileHashStore.storeMetadata(metadataStream, null, null);
+                metadataStream.close();
             });
         }
     }
@@ -941,6 +978,7 @@ public class FileHashStoreInterfaceTest {
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
 
                 fileHashStore.storeMetadata(metadataStream, "", null);
+                metadataStream.close();
             });
         }
     }
@@ -960,6 +998,7 @@ public class FileHashStoreInterfaceTest {
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
 
                 fileHashStore.storeMetadata(metadataStream, "     ", null);
+                metadataStream.close();
             });
         }
     }
@@ -991,6 +1030,7 @@ public class FileHashStoreInterfaceTest {
                 String formatId = "https://ns.dataone.org/service/types/v2.0#SystemMetadata";
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
                 String metadataPath = fileHashStore.storeMetadata(metadataStream, pid, formatId);
+                metadataStream.close();
                 // Calculate absolute path
                 String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
                 Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
@@ -1006,6 +1046,7 @@ public class FileHashStoreInterfaceTest {
                 String formatId = "https://ns.dataone.org/service/types/v2.0#SystemMetadata";
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
                 String metadataPath = fileHashStore.storeMetadata(metadataStream, pid, formatId);
+                metadataStream.close();
                 // Calculate absolute path
                 String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
                 Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
@@ -1021,6 +1062,7 @@ public class FileHashStoreInterfaceTest {
                 String formatId = "https://ns.dataone.org/service/types/v2.0#SystemMetadata";
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
                 String metadataPath = fileHashStore.storeMetadata(metadataStream, pid, formatId);
+                metadataStream.close();
                 // Calculate absolute path
                 String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
                 Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
@@ -1065,6 +1107,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Retrieve object
             InputStream objectCidInputStream = fileHashStore.retrieveObject(pid);
@@ -1135,6 +1178,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Retrieve object
             InputStream objectCidInputStream;
@@ -1185,6 +1229,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             fileHashStore.storeMetadata(metadataStream, pid, null);
+            metadataStream.close();
 
             String storeFormatId = (String) fhsProperties.get("storeMetadataNamespace");
 
@@ -1206,6 +1251,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             fileHashStore.storeMetadata(metadataStream, pid, null);
+            metadataStream.close();
 
             InputStream metadataCidInputStream = fileHashStore.retrieveMetadata(pid);
             assertNotNull(metadataCidInputStream);
@@ -1308,6 +1354,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             fileHashStore.storeMetadata(metadataStream, pid, null);
+            metadataStream.close();
 
             String storeFormatId = (String) fhsProperties.get("storeMetadataNamespace");
 
@@ -1385,6 +1432,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Get metadata file
             Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
@@ -1393,10 +1441,13 @@ public class FileHashStoreInterfaceTest {
             String metadataPathString = fileHashStore.storeMetadata(
                 metadataStream, pid, testFormatId
             );
-            String metadataDefaultPathString = fileHashStore.storeMetadata(metadataStream, pid);
+            metadataStream.close();
+            InputStream metadataStreamTwo = Files.newInputStream(testMetaDataFile);
+            String metadataDefaultPathString = fileHashStore.storeMetadata(metadataStreamTwo, pid);
             Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
             Path metadataPath = Paths.get(metadataPathString);
             Path metadataDefaultPath = Paths.get(metadataDefaultPathString);
+            metadataStreamTwo.close();
 
             // Confirm expected documents exist
             assertTrue(Files.exists(metadataPath));
@@ -1425,6 +1476,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Get metadata file
             Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -1451,6 +1503,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
             fileHashStore.deleteObject(fhsDeleteTypePid, pid);
@@ -1481,6 +1534,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
             String cid = objInfo.getCid();
 
             // Path objAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -1507,6 +1561,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
             String pidExtra = "dou.test" + pid;
             String cid = objInfo.getCid();
             fileHashStore.tagObject(pidExtra, cid);
@@ -1536,6 +1591,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
             String cid = objInfo.getCid();
             String pidExtra = "dou.test" + pid;
             Path objRealPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -1632,6 +1688,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
             String cid = objInfo.getCid();
 
             fileHashStore.deleteObject(fhsDeleteTypeCid, cid);
@@ -1662,6 +1719,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
             String cid = objInfo.getCid();
 
             fileHashStore.deleteObject(fhsDeleteTypeCid, cid);
@@ -1735,6 +1793,7 @@ public class FileHashStoreInterfaceTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             fileHashStore.storeMetadata(metadataStream, pid, null);
+            metadataStream.close();
 
             String storeFormatId = (String) fhsProperties.get("storeMetadataNamespace");
             fileHashStore.deleteMetadata(pid, storeFormatId);
@@ -1768,8 +1827,14 @@ public class FileHashStoreInterfaceTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             fileHashStore.storeMetadata(metadataStream, pid, null);
-            fileHashStore.storeMetadata(metadataStream, pid, formatIdTwo);
-            fileHashStore.storeMetadata(metadataStream, pid, formatIdThree);
+            metadataStream.close();
+            InputStream metadataStreamTwo = Files.newInputStream(testMetaDataFile);
+            fileHashStore.storeMetadata(metadataStreamTwo, pid, formatIdTwo);
+            metadataStreamTwo.close();
+            InputStream metadataStreamThree = Files.newInputStream(testMetaDataFile);
+            fileHashStore.storeMetadata(metadataStreamThree, pid, formatIdThree);
+            metadataStreamThree.close();
+
 
             fileHashStore.deleteMetadata(pid);
 
@@ -1885,6 +1950,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
 
             // Then get the checksum
             String pidHexDigest = fileHashStore.getHexDigest(pid, "SHA-256");
@@ -1951,6 +2017,7 @@ public class FileHashStoreInterfaceTest {
 
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+                dataStream.close();
 
                 fileHashStore.getHexDigest(pid, "BLAKE2S");
             });
@@ -1970,6 +2037,7 @@ public class FileHashStoreInterfaceTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
 
             String cidRetrieved = fileHashStore.findObject(pid);
             assertEquals(cidRetrieved, objInfo.getCid());

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -184,6 +184,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Check id (sha-256 hex digest of the ab_id, aka object_cid)
             String objContentId = testData.pidData.get(pid).get("sha256");
@@ -202,6 +203,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.putObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             // Check id (sha-256 hex digest of the ab_id (pid))
             long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
@@ -220,6 +222,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata address = fileHashStore.putObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             Map<String, String> hexDigests = address.getHexDigests();
 
@@ -252,6 +255,7 @@ public class FileHashStoreProtectedTest {
         ObjectMetadata address = fileHashStore.putObject(
             dataStream, pid, null, checksumCorrect, "MD2", -1
         );
+        dataStream.close();
 
         String objCid = address.getCid();
         // Get relative path
@@ -276,6 +280,7 @@ public class FileHashStoreProtectedTest {
 
         InputStream dataStream = Files.newInputStream(testDataFile);
         fileHashStore.putObject(dataStream, pid, "MD2", null, null, -1);
+        dataStream.close();
 
         String md2 = testData.pidData.get(pid).get("md2");
         assertEquals(checksumCorrect, md2);
@@ -295,6 +300,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.putObject(dataStream, pid, null, checksumIncorrect, "MD2", -1);
+            dataStream.close();
         });
     }
 
@@ -310,6 +316,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.putObject(dataStream, pid, null, "   ", "MD2", -1);
+            dataStream.close();
         });
     }
 
@@ -325,6 +332,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.putObject(dataStream, pid, null, null, "MD2", -1);
+            dataStream.close();
         });
     }
 
@@ -340,6 +348,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.putObject(dataStream, pid, null, "abc", "   ", -1);
+            dataStream.close();
         });
     }
 
@@ -354,6 +363,7 @@ public class FileHashStoreProtectedTest {
             Path testDataFile = testData.getTestFile(pid);
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.putObject(dataStream, pid, null, "abc", null, -1);
+            dataStream.close();
         });
     }
 
@@ -372,6 +382,7 @@ public class FileHashStoreProtectedTest {
             ObjectMetadata objInfo = fileHashStore.putObject(
                 dataStream, pid, null, null, null, objectSize
             );
+            dataStream.close();
 
             // Check id (sha-256 hex digest of the ab_id (pid))
             assertEquals(objectSize, objInfo.getSize());
@@ -392,6 +403,7 @@ public class FileHashStoreProtectedTest {
                 ObjectMetadata objInfo = fileHashStore.putObject(
                     dataStream, pid, null, null, null, 1000
                 );
+                dataStream.close();
 
                 // Check id (sha-256 hex digest of the ab_id (pid))
                 long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
@@ -412,11 +424,13 @@ public class FileHashStoreProtectedTest {
 
         InputStream dataStream = Files.newInputStream(testDataFile);
         fileHashStore.putObject(dataStream, pid, null, null, null, -1);
+        dataStream.close();
 
         // Try duplicate upload
         String pidTwo = pid + ".test";
         InputStream dataStreamTwo = Files.newInputStream(testDataFile);
         fileHashStore.putObject(dataStreamTwo, pidTwo, null, null, null, -1);
+        dataStreamTwo.close();
 
         // Confirm there are no files in 'objects/tmp' directory
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
@@ -436,6 +450,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.putObject(dataStream, pid, "SM2", null, null, -1);
+            dataStream.close();
         });
     }
 
@@ -451,6 +466,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.putObject(dataStream, pid, "   ", null, null, -1);
+            dataStream.close();
         });
     }
 
@@ -470,6 +486,7 @@ public class FileHashStoreProtectedTest {
             Map<String, String> hexDigests = fileHashStore.writeToTmpFileAndGenerateChecksums(
                 newTmpFile, dataStream, null, null
             );
+            dataStream.close();
 
             // Validate checksum values
             String md5 = testData.pidData.get(pid).get("md5");
@@ -502,6 +519,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.writeToTmpFileAndGenerateChecksums(newTmpFile, dataStream, addAlgo, null);
+            dataStream.close();
 
             long testDataFileSize = Files.size(testDataFile);
             long tmpFileSize = Files.size(newTmpFile.toPath());
@@ -528,6 +546,7 @@ public class FileHashStoreProtectedTest {
             Map<String, String> hexDigests = fileHashStore.writeToTmpFileAndGenerateChecksums(
                 newTmpFile, dataStream, addAlgo, null
             );
+            dataStream.close();
 
             // Validate checksum values
             String md2 = testData.pidData.get(pid).get("md2");
@@ -554,6 +573,7 @@ public class FileHashStoreProtectedTest {
             Map<String, String> hexDigests = fileHashStore.writeToTmpFileAndGenerateChecksums(
                 newTmpFile, dataStream, null, checksumAlgo
             );
+            dataStream.close();
 
             // Validate checksum values
             String sha512224 = testData.pidData.get(pid).get("sha512-224");
@@ -581,6 +601,7 @@ public class FileHashStoreProtectedTest {
             Map<String, String> hexDigests = fileHashStore.writeToTmpFileAndGenerateChecksums(
                 newTmpFile, dataStream, addAlgo, checksumAlgo
             );
+            dataStream.close();
 
             // Validate checksum values
             String md2 = testData.pidData.get(pid).get("md2");
@@ -610,6 +631,7 @@ public class FileHashStoreProtectedTest {
                 fileHashStore.writeToTmpFileAndGenerateChecksums(
                     newTmpFile, dataStream, addAlgo, null
                 );
+                dataStream.close();
             });
         }
     }
@@ -693,6 +715,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             String metadataPath = fileHashStore.putMetadata(metadataStream, pid, null);
+            metadataStream.close();
 
             // Calculate absolute path
             String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
@@ -730,6 +753,7 @@ public class FileHashStoreProtectedTest {
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
 
                 fileHashStore.putMetadata(metadataStream, null, null);
+                metadataStream.close();
             });
         }
     }
@@ -749,6 +773,7 @@ public class FileHashStoreProtectedTest {
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
 
                 fileHashStore.putMetadata(metadataStream, "", null);
+                metadataStream.close();
             });
         }
     }
@@ -768,6 +793,7 @@ public class FileHashStoreProtectedTest {
                 InputStream metadataStream = Files.newInputStream(testMetaDataFile);
 
                 fileHashStore.putMetadata(metadataStream, "     ", null);
+                metadataStream.close();
             });
         }
     }
@@ -788,6 +814,7 @@ public class FileHashStoreProtectedTest {
             boolean metadataWritten = fileHashStore.writeToTmpMetadataFile(
                 newTmpFile, metadataStream
             );
+            metadataStream.close();
             assertTrue(metadataWritten);
         }
     }
@@ -809,6 +836,7 @@ public class FileHashStoreProtectedTest {
             boolean metadataWritten = fileHashStore.writeToTmpMetadataFile(
                 newTmpFile, metadataStream
             );
+            metadataStream.close();
             assertTrue(metadataWritten);
 
             long tmpMetadataFileSize = Files.size(newTmpFile.toPath());
@@ -832,6 +860,7 @@ public class FileHashStoreProtectedTest {
             // Write it to the tmpFile
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             fileHashStore.writeToTmpMetadataFile(newTmpFile, metadataStream);
+            metadataStream.close();
 
             // Create InputStream to tmp File
             InputStream metadataStoredStream;
@@ -852,6 +881,7 @@ public class FileHashStoreProtectedTest {
                 while ((bytesRead = metadataStoredStream.read(buffer)) != -1) {
                     sha256.update(buffer, 0, bytesRead);
                 }
+                metadataStoredStream.close();
 
             } catch (IOException ioe) {
                 ioe.printStackTrace();
@@ -881,12 +911,14 @@ public class FileHashStoreProtectedTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+            dataStream.close();
 
             String pidTwo = pid + ".test";
             InputStream dataStreamDup = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStreamDup, pidTwo, null, null, null, -1
             );
+            dataStreamDup.close();
 
             String cid = objInfo.getCid();
             Path absCidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
@@ -907,6 +939,7 @@ public class FileHashStoreProtectedTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
 
             String cid = objInfo.getCid();
             Path absCidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
@@ -926,6 +959,7 @@ public class FileHashStoreProtectedTest {
             InputStream dataStream = Files.newInputStream(testDataFile);
             // Store object only
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
             String cid = objInfo.getCid();
 
             // Try deleting the object
@@ -958,6 +992,7 @@ public class FileHashStoreProtectedTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
             String cid = objInfo.getCid();
 
             // Try deleting the object
@@ -980,6 +1015,7 @@ public class FileHashStoreProtectedTest {
 
         InputStream dataStream = Files.newInputStream(testDataFile);
         ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
+        dataStream.close();
         String cid = objInfo.getCid();
 
         Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
@@ -1003,6 +1039,7 @@ public class FileHashStoreProtectedTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
             String cid = objInfo.getCid();
 
             // Manually form the permanent address of the actual cid
@@ -1033,6 +1070,7 @@ public class FileHashStoreProtectedTest {
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
             String metadataPath = fileHashStore.storeMetadata(metadataStream, pid);
+            metadataStream.close();
 
             Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
             String storeFormatId = fhsProperties.getProperty("storeMetadataNamespace");
@@ -1074,6 +1112,7 @@ public class FileHashStoreProtectedTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
             String cid = objInfo.getCid();
 
             // Manually form the permanent address of the actual cid
@@ -1109,6 +1148,7 @@ public class FileHashStoreProtectedTest {
             ObjectMetadata objInfo = fileHashStore.storeObject(
                 dataStream, pid, null, null, null, -1
             );
+            dataStream.close();
             String cid = objInfo.getCid();
 
             // Manually form the permanent address of the actual cid

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -434,6 +434,7 @@ public class FileHashStorePublicTest {
 
                 InputStream dataStream = Files.newInputStream(testDataFile);
                 secondHashStore.storeObject(dataStream, pid, null, null, null, -1);
+                dataStream.close();
             }
 
             // Delete configuration

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -408,6 +408,7 @@ public class FileHashStoreReferencesTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
 
             String defaultStoreAlgorithm = fhsProperties.getProperty("storeAlgorithm");
 
@@ -433,6 +434,7 @@ public class FileHashStoreReferencesTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
 
             // Get verifyObject args
             String expectedChecksum = testData.pidData.get(pid).get("md2");
@@ -456,6 +458,7 @@ public class FileHashStoreReferencesTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
 
             assertThrows(UnsupportedHashAlgorithmException.class, () -> {
                 fileHashStore.verifyObject(
@@ -476,6 +479,7 @@ public class FileHashStoreReferencesTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
 
             String defaultStoreAlgorithm = fhsProperties.getProperty("storeAlgorithm");
 
@@ -502,6 +506,7 @@ public class FileHashStoreReferencesTest {
 
             InputStream dataStream = Files.newInputStream(testDataFile);
             ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
 
             String defaultStoreAlgorithm = fhsProperties.getProperty("storeAlgorithm");
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -514,16 +514,6 @@ public class FileHashStoreReferencesTest {
                     objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize
                 );
             });
-
-            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
-            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
-            String actualCid = objInfo.getCid();
-            String cidShardString = FileHashStoreUtility.getHierarchicalPathString(
-                storeDepth, storeWidth, actualCid
-            );
-            Path objectStoreDirectory = rootDirectory.resolve("objects").resolve(cidShardString);
-            assertTrue(Files.exists(objectStoreDirectory));
-
         }
     }
 }


### PR DESCRIPTION
**Summary of Changes:**
- Calling `verifyObject` no longer returns a boolean, but throws custom exception classes when:
    - A given `checksum` does not match what has been calculated
    - A given `size` does not match what has been calculated
    - A `checksumAlgorithm` is not supported
- `verifyObject` now attempts to calculate the `checksum` for a given `checksumAlgorithm` if it is supported and is not part of the default hexDigests map