### PR TITLE
Feature-69: `HashStore` Initialization Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Contact us: support@dataone.org
 - [DataONE discussions](https://github.com/DataONEorg/dataone/discussions)
 
-HashStore is a server-side java library implementing a content-based identifier file system for storing and accessing data and metadata for DataONE services.  The package is used in DataONE system components that need direct, filesystem-based access to data objects, their system metadata, and extended metadata about the objects. This package is a core component of the [DataONE federation](https://dataone.org), and supports large-scale object storage for a variety of repositories, including the [KNB Data Repository](http://knb.ecoinformatics.org), the [NSF Arctic Data Center](https://arcticdata.io/catalog/), the [DataONE search service](https://search.dataone.org), and other repositories.
+HashStore is a server-side java library that implements an object storage file system for storing and accessing data and metadata for DataONE services. The package is used in DataONE system components that need direct, filesystem-based access to data objects, their system metadata, and extended metadata about the objects. This package is a core component of the [DataONE federation](https://dataone.org), and supports large-scale object storage for a variety of repositories, including the [KNB Data Repository](http://knb.ecoinformatics.org), the [NSF Arctic Data Center](https://arcticdata.io/catalog/), the [DataONE search service](https://search.dataone.org), and other repositories.
 
 DataONE in general, and HashStore in particular, are open source, community projects.  We [welcome contributions](https://github.com/DataONEorg/hashstore-java/blob/main/CONTRIBUTING.md) in many forms, including code, graphics, documentation, bug reports, testing, etc.  Use the [DataONE discussions](https://github.com/DataONEorg/dataone/discussions) to discuss these contributions with us.
 
@@ -17,7 +17,7 @@ Documentation is a work in progress, and can be found on the [Metacat repository
 
 ## HashStore Overview
 
-HashStore is a content-addressable file management system that utilizes the content identifier of an object to address files. The system stores both objects, references (refs) and metadata in its respective directories and provides an API for interacting with the store. HashStore storage classes (like `FileHashStore`) must implement the HashStore interface to ensure the expected usage of HashStore.
+HashStore is an object storage system that provides persistent file-based storage using content hashes to de-duplicate data. The system stores both objects, references (refs) and metadata in its respective directories and utilizes an identifier-based API for interacting with the store. HashStore storage classes (like `FileHashStore`) must implement the HashStore interface to ensure the expected usage of HashStore.
 
 ###### Public API Methods
 - storeObject
@@ -188,7 +188,7 @@ $ mvn clean package -Dmaven.test.skip=true
 # Get help
 $ java -cp ./target/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.HashStoreClient -h
 
-# Step 2:
+# Step 2: Determine where your hashstore should live (ex. `/var/hashstore`)
 ## Create a HashStore (long option)
 $ java -cp ./target/hashstore-1.0-SNAPSHOT.jar org.dataone.hashstore.HashStoreClient --createhashstore --storepath=/path/to/store --storedepth=3 --storewidth=2 --storealgo=SHA-256 --storenamespace=http://ns.dataone.org/service/types/v2.0
 

--- a/src/main/java/org/dataone/hashstore/HashStoreFactory.java
+++ b/src/main/java/org/dataone/hashstore/HashStoreFactory.java
@@ -53,13 +53,13 @@ public class HashStoreFactory {
 
         } catch (ClassNotFoundException cnfe) {
             String errMsg = "HashStoreFactory - Unable to find 'FileHashStore' classPackage: "
-                + classPackage + " - " + cnfe.getMessage();
+                + classPackage + " - " + cnfe.getCause();
             logHashStore.error(errMsg);
             throw new HashStoreFactoryException(errMsg);
 
         } catch (NoSuchMethodException nsme) {
             String errMsg = "HashStoreFactory - Constructor not found for 'FileHashStore': "
-                + classPackage + " - " + nsme.getMessage();
+                + classPackage + " - " + nsme.getCause();
             logHashStore.error(errMsg);
             throw new HashStoreFactoryException(errMsg);
 
@@ -67,22 +67,20 @@ public class HashStoreFactory {
             String errMsg =
                 "HashStoreFactory - Executing method does not have access to the definition of"
                     + " the specified class , field, method or constructor. " + iae
-                        .getMessage();
+                        .getCause();
             logHashStore.error(errMsg);
             throw new HashStoreFactoryException(errMsg);
 
         } catch (InstantiationException ie) {
             String errMsg = "HashStoreFactory - Error instantiating 'FileHashStore'"
-                + "(likely related to `.newInstance()`): " + ie.getMessage();
+                + "(likely related to `.newInstance()`): " + ie.getCause();
             logHashStore.error(errMsg);
             ie.printStackTrace();
             throw new HashStoreFactoryException(errMsg);
 
         } catch (InvocationTargetException ite) {
-            String errMsg = "HashStoreFactory - Error creating 'FileHashStore' instance: " + ite
-                .getMessage();
+            String errMsg = "HashStoreFactory - Error creating 'FileHashStore' instance: " + ite.getCause();
             logHashStore.error(errMsg);
-            ite.printStackTrace();
             throw new HashStoreFactoryException(errMsg);
 
         }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -278,19 +278,27 @@ public class FileHashStore implements HashStore {
                 "store metadata namespace", storeMetadataNamespace, existingStoreMetadataNs);
 
         } else {
-            // Check if HashStore exists at the given store path (and is missing config)
+            // Check if HashStore related folders exist at the given store path
             logFileHashStore.debug(
                 "FileHashStore - 'hashstore.yaml' not found, check store path for"
                     + " objects and directories."
             );
 
             if (Files.isDirectory(storePath)) {
-                if (FileHashStoreUtility.dirContainsFiles(storePath)) {
-                    String errMsg = "FileHashStore - Missing 'hashstore.yaml' but directories"
-                        + " and/or objects found.";
-                    logFileHashStore.fatal(errMsg);
-                    throw new IllegalStateException(errMsg);
-
+                Path[] conflictingDirectories = {
+                    storePath.resolve("objects"),
+                    storePath.resolve("metadata"),
+                    storePath.resolve("refs")
+                };
+                for (Path dir : conflictingDirectories) {
+                    if (Files.exists(dir) && Files.isDirectory(dir)) {
+                        String errMsg = "FileHashStore - Unable to initialize HashStore."
+                            + "`hashstore.yaml` is not found but potential conflicting"
+                            + " directory exists: " + dir + ". Please choose a new folder or"
+                            + " delete the conflicting directory and try again.";
+                        logFileHashStore.fatal(errMsg);
+                        throw new IllegalStateException(errMsg);
+                    }
                 }
             }
             logFileHashStore.debug(

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -276,14 +276,14 @@ public class FileHashStore implements HashStore {
                                                      existingStoreAlgorithm);
             FileHashStoreUtility.checkObjectEquality(
                 "store metadata namespace", storeMetadataNamespace, existingStoreMetadataNs);
+            logFileHashStore.info("FileHashStore - 'hashstore.yaml' found and HashStore verified");
 
         } else {
             // Check if HashStore related folders exist at the given store path
             logFileHashStore.debug(
-                "FileHashStore - 'hashstore.yaml' not found, check store path for"
-                    + " objects and directories."
+                "FileHashStore - 'hashstore.yaml' not found, checking store path for"
+                    + " `/objects`, `/metadata` and `/refs` directories."
             );
-
             if (Files.isDirectory(storePath)) {
                 Path[] conflictingDirectories = {
                     storePath.resolve("objects"),

--- a/src/test/java/org/dataone/hashstore/HashStoreClientTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreClientTest.java
@@ -35,7 +35,7 @@ public class HashStoreClientTest {
     @BeforeEach
     public void getHashStore() {
         String classPackage = "org.dataone.hashstore.filehashstore.FileHashStore";
-        Path rootDirectory = tempFolder.resolve("metacat");
+        Path rootDirectory = tempFolder.resolve("hashstore");
 
         Properties storeProperties = new Properties();
         storeProperties.setProperty("storePath", rootDirectory.toString());
@@ -43,7 +43,7 @@ public class HashStoreClientTest {
         storeProperties.setProperty("storeWidth", "2");
         storeProperties.setProperty("storeAlgorithm", "SHA-256");
         storeProperties.setProperty(
-            "storeMetadataNamespace", "http://ns.dataone.org/service/types/v2.0"
+            "storeMetadataNamespace", "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
         );
 
         try {
@@ -117,7 +117,7 @@ public class HashStoreClientTest {
     public void client_createHashStore() throws Exception {
         String optCreateHashstore = "-chs";
         String optStore = "-store";
-        String optStorePath = tempFolder + "/metacat";
+        String optStorePath = tempFolder + "/hashstore";
         String optStoreDepth = "-dp";
         String optStoreDepthValue = "3";
         String optStoreWidth = "-wp";
@@ -125,7 +125,7 @@ public class HashStoreClientTest {
         String optAlgo = "-ap";
         String optAlgoValue = "SHA-256";
         String optFormatId = "-nsp";
-        String optFormatIdValue = "http://ns.dataone.org/service/types/v2.0";
+        String optFormatIdValue = "https://ns.dataone.org/service/types/v2.0#SystemMetadata";
         String[] args = {optCreateHashstore, optStore, optStorePath, optStoreDepth,
             optStoreDepthValue, optStoreWidth, optStoreWidthValue, optAlgo, optAlgoValue,
             optFormatId, optFormatIdValue};

--- a/src/test/java/org/dataone/hashstore/HashStoreTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreTest.java
@@ -1,6 +1,7 @@
 package org.dataone.hashstore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,7 +29,7 @@ public class HashStoreTest {
     @BeforeEach
     public void getHashStore() {
         String classPackage = "org.dataone.hashstore.filehashstore.FileHashStore";
-        Path rootDirectory = tempFolder.resolve("metacat");
+        Path rootDirectory = tempFolder.resolve("hashstore");
 
         Properties storeProperties = new Properties();
         storeProperties.setProperty("storePath", rootDirectory.toString());
@@ -72,7 +73,7 @@ public class HashStoreTest {
     public void hashStore_classPackageNull() {
         assertThrows(HashStoreFactoryException.class, () -> {
             Properties storeProperties = new Properties();
-            storeProperties.setProperty("storePath", "/test");
+            storeProperties.setProperty("storePath", "/hashstore");
             storeProperties.setProperty("storeDepth", "3");
             storeProperties.setProperty("storeWidth", "2");
             storeProperties.setProperty("storeAlgorithm", "SHA-256");
@@ -134,5 +135,83 @@ public class HashStoreTest {
             String objContentId = testData.pidData.get(pid).get("sha256");
             assertEquals(objContentId, objInfo.getCid());
         }
+    }
+
+    /**
+     * Confirm factory throws exception when a given folder is empty but an objects folder exists
+     */
+    @Test
+    public void getHashStore_objFolderExists() throws Exception {
+        String classPackage = "org.dataone.hashstore.filehashstore.FileHashStore";
+        Path rootDirectory = tempFolder.resolve("doutest/hashstore");
+
+        Path conflictingObjDirectory = rootDirectory.resolve("objects");
+        Files.createDirectories(rootDirectory.resolve("objects"));
+        assertTrue(Files.exists(conflictingObjDirectory));
+
+        Properties storeProperties = new Properties();
+        storeProperties.setProperty("storePath", rootDirectory.toString());
+        storeProperties.setProperty("storeDepth", "3");
+        storeProperties.setProperty("storeWidth", "2");
+        storeProperties.setProperty("storeAlgorithm", "SHA-256");
+        storeProperties.setProperty(
+            "storeMetadataNamespace", "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
+        );
+
+        assertThrows(HashStoreFactoryException.class, () -> {
+            hashStore = HashStoreFactory.getHashStore(classPackage, storeProperties);
+        });
+    }
+
+    /**
+     * Confirm factory throws exception when a given folder is empty but an objects folder exists
+     */
+    @Test
+    public void getHashStore_metadataFolderExists() throws Exception {
+        String classPackage = "org.dataone.hashstore.filehashstore.FileHashStore";
+        Path rootDirectory = tempFolder.resolve("doutest/hashstore");
+
+        Path conflictingObjDirectory = rootDirectory.resolve("metadata");
+        Files.createDirectories(rootDirectory.resolve("metadata"));
+        assertTrue(Files.exists(conflictingObjDirectory));
+
+        Properties storeProperties = new Properties();
+        storeProperties.setProperty("storePath", rootDirectory.toString());
+        storeProperties.setProperty("storeDepth", "3");
+        storeProperties.setProperty("storeWidth", "2");
+        storeProperties.setProperty("storeAlgorithm", "SHA-256");
+        storeProperties.setProperty(
+            "storeMetadataNamespace", "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
+        );
+
+        assertThrows(HashStoreFactoryException.class, () -> {
+            hashStore = HashStoreFactory.getHashStore(classPackage, storeProperties);
+        });
+    }
+
+    /**
+     * Confirm factory throws exception when a given folder is empty but an objects folder exists
+     */
+    @Test
+    public void getHashStore_refsFolderExists() throws Exception {
+        String classPackage = "org.dataone.hashstore.filehashstore.FileHashStore";
+        Path rootDirectory = tempFolder.resolve("doutest/hashstore");
+
+        Path conflictingObjDirectory = rootDirectory.resolve("refs");
+        Files.createDirectories(rootDirectory.resolve("refs"));
+        assertTrue(Files.exists(conflictingObjDirectory));
+
+        Properties storeProperties = new Properties();
+        storeProperties.setProperty("storePath", rootDirectory.toString());
+        storeProperties.setProperty("storeDepth", "3");
+        storeProperties.setProperty("storeWidth", "2");
+        storeProperties.setProperty("storeAlgorithm", "SHA-256");
+        storeProperties.setProperty(
+            "storeMetadataNamespace", "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
+        );
+
+        assertThrows(HashStoreFactoryException.class, () -> {
+            hashStore = HashStoreFactory.getHashStore(classPackage, storeProperties);
+        });
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -65,7 +65,7 @@ public class FileHashStoreInterfaceTest {
      */
     @BeforeEach
     public void initializeFileHashStore() {
-        rootDirectory = tempFolder.resolve("metacat");
+        rootDirectory = tempFolder.resolve("hashstore");
         fhsDeleteTypePid = HashStoreIdTypes.pid.getName();
         fhsDeleteTypeCid = HashStoreIdTypes.cid.getName();
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -39,7 +39,7 @@ public class FileHashStoreProtectedTest {
      */
     @BeforeEach
     public void initializeFileHashStore() {
-        Path rootDirectory = tempFolder.resolve("metacat");
+        Path rootDirectory = tempFolder.resolve("hashstore");
 
         Properties storeProperties = new Properties();
         storeProperties.setProperty("storePath", rootDirectory.toString());
@@ -67,7 +67,7 @@ public class FileHashStoreProtectedTest {
      * Non-test method using to generate a temp file
      */
     public File generateTemporaryFile() throws Exception {
-        Path directory = tempFolder.resolve("metacat");
+        Path directory = tempFolder.resolve("hashstore");
         // newFile
         return FileHashStoreUtility.generateTmpFile("testfile", directory);
     }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStorePublicTest.java
@@ -37,7 +37,7 @@ public class FileHashStorePublicTest {
     @BeforeEach
     public void initializeFileHashStore() {
         Path root = tempFolder;
-        rootDirectory = root.resolve("metacat");
+        rootDirectory = root.resolve("hashstore");
         objStringFull = rootDirectory.resolve("objects");
         objTmpStringFull = rootDirectory.resolve("objects/tmp");
         metadataStringFull = rootDirectory.resolve("metadata");

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -42,7 +42,7 @@ public class FileHashStoreReferencesTest {
      */
     @BeforeEach
     public void initializeFileHashStore() {
-        rootDirectory = tempFolder.resolve("metacat");
+        rootDirectory = tempFolder.resolve("hashstore");
 
         Properties storeProperties = new Properties();
         storeProperties.setProperty("storePath", rootDirectory.toString());


### PR DESCRIPTION
**Summary of Changes:**
- Updated the init process to check for the existence of specific conflicting `HashStore` directories (objects, metadata and refs) rather than any folder or files when throwing an exception
- Updated junit test classes to improve clarity around `storePath` and the correct metadata namespace for sysmeta documents.
- Updated README.md