### PR TITLE
Feature-72: `findObject` Update

### DIFF
--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
+import java.util.Map;
 
 import org.dataone.hashstore.exceptions.NonMatchingChecksumException;
 import org.dataone.hashstore.exceptions.NonMatchingObjSizeException;
@@ -162,7 +163,8 @@ public interface HashStore {
             UnsupportedHashAlgorithmException, IOException;
 
         /**
-         * Checks whether an object referenced by a pid exists and returns the content identifier.
+         * Checks whether an object referenced by a pid exists and returns a map containing the
+         * absolute path to the object, pid refs file, cid refs file and sysmeta document.
          * 
          * @param pid Authority-based identifier
          * @return Content identifier (cid)
@@ -177,7 +179,7 @@ public interface HashStore {
          * @throws PidNotFoundInCidRefsFileException When pid and cid ref files exists but the
          *                                           expected pid is not found in the cid refs file.
          */
-        public String findObject(String pid) throws NoSuchAlgorithmException, IOException,
+        public Map<String, String> findObject(String pid) throws NoSuchAlgorithmException, IOException,
                 OrphanPidRefsFileException, PidNotFoundInCidRefsFileException;
 
         /**

--- a/src/main/java/org/dataone/hashstore/HashStoreClient.java
+++ b/src/main/java/org/dataone/hashstore/HashStoreClient.java
@@ -147,7 +147,21 @@ public class HashStoreClient {
                     FileHashStoreUtility.ensureNotNull(pid, "-pid", "HashStoreClient");
 
                     Map<String, String> objInfoMap = hashStore.findObject(pid);
-                    System.out.println(objInfoMap.get("cid"));
+                    String cid = objInfoMap.get("cid");
+                    String cidPath = objInfoMap.get("cid_object_path");
+                    String cidRefsPath = objInfoMap.get("cid_refs_path");
+                    String pidRefsPath = objInfoMap.get("pid_refs_path");
+                    String sysmetaPath = objInfoMap.get("sysmeta_path");
+                    System.out.println("Content Identifier:");
+                    System.out.println(cid);
+                    System.out.println("Object Path:");
+                    System.out.println(cidPath);
+                    System.out.println("Cid Reference File Path:");
+                    System.out.println(cidRefsPath);
+                    System.out.println("Pid Reference File Path:");
+                    System.out.println(pidRefsPath);
+                    System.out.println("Sysmeta Path:");
+                    System.out.println(sysmetaPath);
 
                 } else if (cmd.hasOption("storeobject")) {
                     System.out.println("Storing object");

--- a/src/main/java/org/dataone/hashstore/HashStoreClient.java
+++ b/src/main/java/org/dataone/hashstore/HashStoreClient.java
@@ -146,8 +146,8 @@ public class HashStoreClient {
                     String pid = cmd.getOptionValue("pid");
                     FileHashStoreUtility.ensureNotNull(pid, "-pid", "HashStoreClient");
 
-                    String cid = hashStore.findObject(pid);
-                    System.out.println(cid);
+                    Map<String, String> objInfoMap = hashStore.findObject(pid);
+                    System.out.println(objInfoMap.get("cid"));
 
                 } else if (cmd.hasOption("storeobject")) {
                     System.out.println("Storing object");

--- a/src/main/java/org/dataone/hashstore/ObjectMetadata.java
+++ b/src/main/java/org/dataone/hashstore/ObjectMetadata.java
@@ -42,12 +42,9 @@ public class ObjectMetadata {
 
     /**
      * Set the persistent identifier
-     * 
-     * @return pid
      */
-    public String setPid(String pid) {
+    public void setPid(String pid) {
         this.pid = pid;
-        return pid;
     }
 
     /**

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -848,6 +848,17 @@ public class FileHashStore implements HashStore {
                     Map<String, String> objInfoMap = new HashMap<>();
                     objInfoMap.put("cid", cid);
                     objInfoMap.put("object_path", realPath.toString());
+                    objInfoMap.put("pid_refs_path", absPidRefsPath.toString());
+                    objInfoMap.put("cid_refs_path", absCidRefsPath.toString());
+                    // If the default system metadata exists, include it
+                    Path metadataPidExpectedPath = getExpectedPath(
+                        pid, "metadata", DEFAULT_METADATA_NAMESPACE
+                    );
+                    if (Files.exists(metadataPidExpectedPath)) {
+                        objInfoMap.put("sysmeta_path", metadataPidExpectedPath.toString());
+                    } else {
+                        objInfoMap.put("sysmeta_path", "Does not exist");
+                    }
                     return objInfoMap;
 
                 } else {

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -847,9 +847,9 @@ public class FileHashStore implements HashStore {
                 if (Files.exists(realPath)) {
                     Map<String, String> objInfoMap = new HashMap<>();
                     objInfoMap.put("cid", cid);
-                    objInfoMap.put("object_path", realPath.toString());
-                    objInfoMap.put("pid_refs_path", absPidRefsPath.toString());
+                    objInfoMap.put("cid_object_path", realPath.toString());
                     objInfoMap.put("cid_refs_path", absCidRefsPath.toString());
+                    objInfoMap.put("pid_refs_path", absPidRefsPath.toString());
                     // If the default system metadata exists, include it
                     Path metadataPidExpectedPath = getExpectedPath(
                         pid, "metadata", DEFAULT_METADATA_NAMESPACE

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -813,7 +813,7 @@ public class FileHashStore implements HashStore {
     }
 
     @Override
-    public String findObject(String pid) throws NoSuchAlgorithmException, IOException,
+    public Map<String, String> findObject(String pid) throws NoSuchAlgorithmException, IOException,
         OrphanPidRefsFileException, PidNotFoundInCidRefsFileException, OrphanRefsFilesException {
         logFileHashStore.debug("FileHashStore.findObject - Called to find object for pid: " + pid);
         FileHashStoreUtility.ensureNotNull(pid, "pid", "findObject");
@@ -845,7 +845,9 @@ public class FileHashStore implements HashStore {
                 );
                 Path realPath = OBJECT_STORE_DIRECTORY.resolve(objRelativePath);
                 if (Files.exists(realPath)) {
-                    return cid;
+                    Map<String, String> objInfoMap = new HashMap<>();
+                    objInfoMap.put("cid", cid);
+                    return objInfoMap;
 
                 } else {
                     String errMsg = "FileHashStore.findObject - Object with cid: " + cid
@@ -1162,7 +1164,8 @@ public class FileHashStore implements HashStore {
                 // `findObject` which will throw custom exceptions if there is an issue with
                 // the reference files, which help us determine the path to proceed with.
                 try {
-                    cid = findObject(id);
+                    Map<String, String> objInfoMap = findObject(id);
+                    cid = objInfoMap.get("cid");
 
                     // If no exceptions are thrown, we proceed to synchronization based on the `cid`
                     // Multiple threads may access the cid reference file (which contains a list of
@@ -1505,7 +1508,8 @@ public class FileHashStore implements HashStore {
 
         // Find the content identifier
         if (algorithm.equals(OBJECT_STORE_ALGORITHM)) {
-            return findObject(pid);
+            Map<String, String> objInfoMap = findObject(pid);
+            return objInfoMap.get("cid");
 
         } else {
             // Get permanent address of the pid

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -847,6 +847,7 @@ public class FileHashStore implements HashStore {
                 if (Files.exists(realPath)) {
                     Map<String, String> objInfoMap = new HashMap<>();
                     objInfoMap.put("cid", cid);
+                    objInfoMap.put("object_path", realPath.toString());
                     return objInfoMap;
 
                 } else {

--- a/src/test/java/org/dataone/hashstore/HashStoreClientTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreClientTest.java
@@ -508,7 +508,7 @@ public class HashStoreClientTest {
                 "-", "");
             Path cidRefsPath = getObjectAbsPath(
                 testData.pidData.get(pid).get(storeAlgo), "cid"
-            );;
+            );
             Path pidRefsPath = getObjectAbsPath(
                 pid, "pid"
             );
@@ -519,7 +519,7 @@ public class HashStoreClientTest {
             String expectedOutPutPt4 = "Pid Reference File Path:\n" + pidRefsPath + "\n";
             String expectedOutPutPt5 = "Sysmeta Path:\n" + sysMetaPath;
             String expectedOutPutFull =
-                expectedOutPutPt1 + expectedOutPutPt2 + expectedOutPutPt3 + expectedOutPutPt4 + expectedOutPutPt5;;
+                expectedOutPutPt1 + expectedOutPutPt2 + expectedOutPutPt3 + expectedOutPutPt4 + expectedOutPutPt5;
 
 
             // Put things back

--- a/src/test/java/org/dataone/hashstore/HashStoreClientTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreClientTest.java
@@ -91,7 +91,7 @@ public class HashStoreClientTest {
 
     /**
      * Utility method to get absolute path of a given object and objType
-     * ("objects" or "metadata").
+     * ("objects", "metadata", "cid", or "pid").
      */
     public Path getObjectAbsPath(String id, String objType) throws Exception {
         String storeAlgo = hsProperties.getProperty("storeAlgorithm");
@@ -109,7 +109,7 @@ public class HashStoreClientTest {
             // Get pid metadata directory hash(pid)
             String pidHash = FileHashStoreUtility.getPidHexDigest(id, storeAlgo);
             String pidMetadataDirectory = getHierarchicalPathString(shardDepth, shardWidth, pidHash);
-            // Get document name hash(pid+formatId)
+            // Get sysmeta name hash(pid+default_formatId)
             String metadataDocHash =
                 FileHashStoreUtility.getPidHexDigest(id + hsProperties.getProperty(
                     "storeMetadataNamespace"), storeAlgo);
@@ -368,7 +368,7 @@ public class HashStoreClientTest {
             HashStoreClient.main(args);
 
             // Confirm object was deleted
-            Path absPath = getObjectAbsPath(testData.pidData.get(pid).get("object_cid"), "object");
+            Path absPath = getObjectAbsPath(testData.pidData.get(pid).get("sha256"), "object");
             assertFalse(Files.exists(absPath));
 
             // Put things back
@@ -412,10 +412,8 @@ public class HashStoreClientTest {
             HashStoreClient.main(args);
 
             // Confirm metadata was deleted
-            Path absPath = getObjectAbsPath(
-                testData.pidData.get(pid).get("metadata_cid"), "metadata"
-            );
-            assertFalse(Files.exists(absPath));
+            Path sysmetaPath = getObjectAbsPath(pid, "metadata");
+            assertFalse(Files.exists(sysmetaPath));
 
             // Put things back
             System.out.flush();

--- a/src/test/java/org/dataone/hashstore/HashStoreRunnable.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreRunnable.java
@@ -16,7 +16,7 @@ import java.io.InputStream;
 public class HashStoreRunnable implements Runnable {
     public static final int storeObject = 1;
     public static final int deleteObject = 2;
-    private HashStore hashstore = null;
+    private HashStore hashstore;
     private int publicAPIMethod;
     private String pid;
     private InputStream objStream;

--- a/src/test/java/org/dataone/hashstore/HashStoreTest.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreTest.java
@@ -1,7 +1,6 @@
 package org.dataone.hashstore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -35,7 +35,6 @@ import javax.xml.bind.DatatypeConverter;
 
 import org.dataone.hashstore.HashStoreRunnable;
 import org.dataone.hashstore.ObjectMetadata;
-import org.dataone.hashstore.exceptions.NonMatchingChecksumException;
 import org.dataone.hashstore.exceptions.OrphanPidRefsFileException;
 import org.dataone.hashstore.exceptions.OrphanRefsFilesException;
 import org.dataone.hashstore.exceptions.PidNotFoundInCidRefsFileException;

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -2039,8 +2039,8 @@ public class FileHashStoreInterfaceTest {
             );
             dataStream.close();
 
-            String cidRetrieved = fileHashStore.findObject(pid);
-            assertEquals(cidRetrieved, objInfo.getCid());
+            Map<String, String> objInfoMap = fileHashStore.findObject(pid);
+            assertEquals(objInfoMap.get("cid"), objInfo.getCid());
         }
     }
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -2045,6 +2045,35 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
+     * Check that findObject returns cid as expected.
+     */
+    @Test
+    public void findObject_cidPath() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(
+                dataStream, pid, null, null, null, -1
+            );
+            dataStream.close();
+
+            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
+            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
+            Map<String, String> objInfoMap = fileHashStore.findObject(pid);
+            String objectPath = objInfoMap.get("object_path");
+
+            String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
+                storeDepth, storeWidth, objInfo.getCid()
+            );
+            Path realPath = rootDirectory.resolve("objects").resolve(objRelativePath);
+
+            assertEquals(objectPath, realPath.toString());
+        }
+    }
+
+    /**
      * Confirm findObject throws exception when cid object does not exist but reference
      * files exist.
      */

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -1391,7 +1391,7 @@ public class FileHashStoreInterfaceTest {
             String sha256MetadataDigest = DatatypeConverter.printHexBinary(sha256.digest())
                 .toLowerCase();
             String sha256MetadataDigestFromTestData = testData.pidData.get(pid).get(
-                "metadata_sha256"
+                "metadata_cid_sha256"
             );
             assertEquals(sha256MetadataDigest, sha256MetadataDigestFromTestData);
         }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -2062,7 +2062,7 @@ public class FileHashStoreInterfaceTest {
             int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
             int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
             Map<String, String> objInfoMap = fileHashStore.findObject(pid);
-            String objectPath = objInfoMap.get("object_path");
+            String objectPath = objInfoMap.get("cid_object_path");
 
             String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
                 storeDepth, storeWidth, objInfo.getCid()

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -1069,7 +1069,7 @@ public class FileHashStoreProtectedTest {
             Path testMetaDataFile = testData.getTestFile(pidFormatted + ".xml");
 
             InputStream metadataStream = Files.newInputStream(testMetaDataFile);
-            String metadataPath = fileHashStore.storeMetadata(metadataStream, pid);
+            fileHashStore.storeMetadata(metadataStream, pid);
             metadataStream.close();
 
             Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
@@ -1155,7 +1155,6 @@ public class FileHashStoreProtectedTest {
             Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
             int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
             int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
-            String storeAlgo = fhsProperties.getProperty("storeAlgorithm");
 
             // Cid refs file
             String objShardString = FileHashStoreUtility.getHierarchicalPathString(

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -891,7 +891,7 @@ public class FileHashStoreProtectedTest {
 
             String sha256Digest = DatatypeConverter.printHexBinary(sha256.digest()).toLowerCase();
             String sha256MetadataDigestFromTestData = testData.pidData.get(pid).get(
-                "metadata_sha256"
+                "metadata_cid_sha256"
             );
             assertEquals(sha256Digest, sha256MetadataDigestFromTestData);
 

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -133,7 +133,7 @@ public class FileHashStoreReferencesTest {
 
         // Should not throw any exceptions, everything is where it's supposed to be.
         fileHashStore.tagObject(pid, cid);
-        // Confirm that there is only 1 of each refs file
+        // Confirm that there is only 1 of each ref file
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
         File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();
         assertEquals(1, pidRefsFiles.length);
@@ -162,7 +162,7 @@ public class FileHashStoreReferencesTest {
 
 
     /**
-     * Check tagObject overwrites a oprhaned pid refs file.
+     * Check tagObject overwrites an orphaned pid refs file.
      */
     @Test
     public void tagObject_pidRefsFileFound_differentCidRetrieved_cidRefsFileNotFound()
@@ -182,7 +182,7 @@ public class FileHashStoreReferencesTest {
         fileHashStore.move(pidRefsTmpFile, absPathPidRefsFile, "refs");
 
         fileHashStore.tagObject(pid, cid);
-        // There should only be 1 of each refs file
+        // There should only be 1 of each ref file
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
         File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();
         assertEquals(1, pidRefsFiles.length);
@@ -203,7 +203,7 @@ public class FileHashStoreReferencesTest {
         Files.delete(cidRefsFilePath);
 
         fileHashStore.tagObject(pid, cid);
-        // Confirm that there is only 1 of each refs file
+        // Confirm that there is only 1 of each ref file
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
         File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();
         assertEquals(1, pidRefsFiles.length);

--- a/src/test/java/org/dataone/hashstore/testdata/TestDataHarness.java
+++ b/src/test/java/org/dataone/hashstore/testdata/TestDataHarness.java
@@ -10,11 +10,10 @@ import java.util.Map;
  * This class returns the test data expected hex digest values
  * 
  * Notes:
- * - "object_cid" is the SHA-256 hash of the pid
  * - algorithms without any prefixes are the algorithm hash of the pid's respective data object
  * content
- * - "metadata_sha256" is the hash of the pid's respective metadata object content identifier
- * - "metacat_cid" is the sha256 hash of the pid + formatId
+ * - "metadata_cid_sha256" is sha256 content identifier of the pid's metadata object
+ * - "sysmeta_address_sha256" is the sha256 hash of the pid + formatId
  * 
  */
 public class TestDataHarness {
@@ -26,10 +25,6 @@ public class TestDataHarness {
                 Map<String, Map<String, String>> pidsAndHexDigests = new HashMap<>();
 
                 Map<String, String> values1 = new HashMap<>();
-                values1.put(
-                        "object_cid",
-                        "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e"
-                );
                 values1.put("md2", "b33c730ac5e36b2b886a9cd14552f42e");
                 values1.put("md5", "db91c910a3202478c8def1071c54aae5");
                 values1.put("sha1", "1fe86e3c8043afa4c70857ca983d740ad8501ccd");
@@ -48,21 +43,17 @@ public class TestDataHarness {
                         "sha512-224", "107f9facb268471de250625440b6c8b7ff8296fbe5d89bed4a61fd35"
                 );
                 values1.put(
-                        "metadata_cid",
+                        "sysmeta_address_sha256",
                         "323e0799524cec4c7e14d31289cefd884b563b5c052f154a066de5ec1e477da7"
                 );
                 values1.put(
-                        "metadata_sha256",
+                        "metadata_cid_sha256",
                         "158d7e55c36a810d7c14479c952a4d0b370f2b844808f2ea2b20d7df66768b04"
                 );
                 values1.put("size", "39993");
                 pidsAndHexDigests.put("doi:10.18739/A2901ZH2M", values1);
 
                 Map<String, String> values2 = new HashMap<>();
-                values2.put(
-                        "object_cid",
-                        "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf"
-                );
                 values2.put("md2", "9c25df1c8ba1d2e57bb3fd4785878b85");
                 values2.put("md5", "f4ea2d07db950873462a064937197b0f");
                 values2.put("sha1", "3d25436c4490b08a2646e283dada5c60e5c0539d");
@@ -81,21 +72,17 @@ public class TestDataHarness {
                         "sha512-224", "7a2b22e36ced9e91cf8cdf6971897ec4ae21780e11d1c3903011af33"
                 );
                 values2.put(
-                        "metadata_cid",
+                        "sysmeta_address_sha256",
                         "ddf07952ef28efc099d10d8b682480f7d2da60015f5d8873b6e1ea75b4baf689"
                 );
                 values2.put(
-                        "metadata_sha256",
+                        "metadata_cid_sha256",
                         "d87c386943ceaeba5644c52b23111e4f47972e6530df0e6f0f41964b25855b08"
                 );
                 values2.put("size", "8724");
                 pidsAndHexDigests.put("jtao.1700.1", values2);
 
                 Map<String, String> values3 = new HashMap<>();
-                values3.put(
-                        "object_cid",
-                        "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6"
-                );
                 values3.put("md2", "9f2b06b300f661ce4398006c41d8aa88");
                 values3.put("md5", "e1932fc75ca94de8b64f1d73dc898079");
                 values3.put("sha1", "c6d2a69a3f5adaf478ba796c114f57b990cf7ad1");
@@ -114,11 +101,11 @@ public class TestDataHarness {
                         "sha512-224", "e1789a91c9df334fdf6ee5d295932ad96028c426a18b17016a627099"
                 );
                 values3.put(
-                        "metadata_cid",
+                        "sysmeta_address_sha256",
                         "9a2e08c666b728e6cbd04d247b9e556df3de5b2ca49f7c5a24868eb27cddbff2"
                 );
                 values3.put(
-                        "metadata_sha256",
+                        "metadata_cid_sha256",
                         "27003e07f2ab374020de73298dd24a1d8b1b57647b8fa3c49db00f8c342afa1d"
                 );
                 values3.put("size", "18699");


### PR DESCRIPTION
**Summary of Changes:**
- `findObject` now returns a map that contains the following keys:
    - cid
    - cid_object_path
    - cid_refs_path
    - pid_refs_path
    - sysmeta_path
- HashStore interface has been updated for `findObject`
- Update junit tests
- Clean up `TestDataHarness` for ambiguity with values