### PR TITLE
Feature-74: `tagObject` Refs File Already Exists

### DIFF
--- a/src/main/java/org/dataone/hashstore/exceptions/HashStoreRefsAlreadyExistException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/HashStoreRefsAlreadyExistException.java
@@ -2,6 +2,9 @@ package org.dataone.hashstore.exceptions;
 
 import java.nio.file.FileAlreadyExistsException;
 
+/**
+ * Custom exception thrown when called to tag a pid and cid, and reference files already exist
+ */
 public class HashStoreRefsAlreadyExistException extends FileAlreadyExistsException {
 
     public HashStoreRefsAlreadyExistException(String message) {

--- a/src/main/java/org/dataone/hashstore/exceptions/HashStoreRefsAlreadyExistException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/HashStoreRefsAlreadyExistException.java
@@ -1,0 +1,11 @@
+package org.dataone.hashstore.exceptions;
+
+import java.nio.file.FileAlreadyExistsException;
+
+public class HashStoreRefsAlreadyExistException extends FileAlreadyExistsException {
+
+    public HashStoreRefsAlreadyExistException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/dataone/hashstore/exceptions/HashStoreServiceException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/HashStoreServiceException.java
@@ -1,7 +1,7 @@
 package org.dataone.hashstore.exceptions;
 
 /**
- * An exception that encapsulates errors from the HashStore service
+ * An exception that encapsulates errors from the HashStore Runnable Test Class
  */
 public class HashStoreServiceException extends Exception {
     public HashStoreServiceException(String message) {

--- a/src/main/java/org/dataone/hashstore/exceptions/PidRefsFileExistsException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/PidRefsFileExistsException.java
@@ -3,7 +3,8 @@ package org.dataone.hashstore.exceptions;
 import java.io.IOException;
 
 /**
- * Custom exception class for FileHashStore pidObjects
+ * Custom exception class thrown when a pid refs file already exists (a single pid can only ever
+ * reference one cid)
  */
 public class PidRefsFileExistsException extends IOException {
     public PidRefsFileExistsException(String message) {

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -36,6 +36,7 @@ import org.apache.commons.logging.LogFactory;
 import org.dataone.hashstore.ObjectMetadata;
 import org.dataone.hashstore.HashStore;
 import org.dataone.hashstore.exceptions.CidNotFoundInPidRefsFileException;
+import org.dataone.hashstore.exceptions.HashStoreRefsAlreadyExistException;
 import org.dataone.hashstore.exceptions.NonMatchingChecksumException;
 import org.dataone.hashstore.exceptions.NonMatchingObjSizeException;
 import org.dataone.hashstore.exceptions.OrphanPidRefsFileException;
@@ -651,10 +652,12 @@ public class FileHashStore implements HashStore {
             // Both files found, confirm that reference files are where they are expected to be
             if (Files.exists(absPidRefsPath) && Files.exists(absCidRefsPath)) {
                 verifyHashStoreRefsFiles(pid, cid, absPidRefsPath, absCidRefsPath);
-                logFileHashStore.info(
-                    "FileHashStore.tagObject - Object with cid: " + cid
-                        + " already exists and is tagged with pid: " + pid
-                );
+                // We throw an exception so the client is aware that everything is in place
+                String errMsg = "FileHashStore.tagObject - Object with cid: " + cid
+                    + " already exists and is tagged with pid: " + pid;
+                logFileHashStore.error(errMsg);
+                throw new HashStoreRefsAlreadyExistException(errMsg);
+
             } else if (Files.exists(absPidRefsPath) && !Files.exists(absCidRefsPath)) {
                 // If pid refs exists, it can only contain and reference one cid
                 // First, compare the cid retrieved from the pid refs file from the supplied cid

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -19,6 +19,7 @@ import java.util.Properties;
 
 import org.dataone.hashstore.ObjectMetadata;
 import org.dataone.hashstore.exceptions.CidNotFoundInPidRefsFileException;
+import org.dataone.hashstore.exceptions.HashStoreRefsAlreadyExistException;
 import org.dataone.hashstore.exceptions.NonMatchingChecksumException;
 import org.dataone.hashstore.exceptions.NonMatchingObjSizeException;
 import org.dataone.hashstore.exceptions.PidNotFoundInCidRefsFileException;
@@ -133,8 +134,10 @@ public class FileHashStoreReferencesTest {
         String cid = "abcdef123456789";
         fileHashStore.tagObject(pid, cid);
 
-        // Should not throw any exceptions, everything is where it's supposed to be.
-        fileHashStore.tagObject(pid, cid);
+        assertThrows(HashStoreRefsAlreadyExistException.class, () -> {
+            fileHashStore.tagObject(pid, cid);
+        });
+
         // Confirm that there is only 1 of each ref file
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
         File[] pidRefsFiles = storePath.resolve("refs/pids").toFile().listFiles();


### PR DESCRIPTION
**Summary of Changes:**
- `tagObject` throws a new custom exception `HashStoreRefsAlreadyExistException` when called to tag files that are already correctly tagged (instead of logging a warning).