### PR TITLE
Feature-82: Remove unused `storeObject` overload methods

### DIFF
--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -86,46 +86,6 @@ public interface HashStore {
                 IOException, PidRefsFileExistsException, RuntimeException, InterruptedException;
 
         /**
-         * @see #storeObject(InputStream, String, String, String, String, long)
-         * 
-         *      Store an object and validate the given checksum & checksum algorithm and size.
-         */
-        public ObjectMetadata storeObject(
-                InputStream object, String pid, String checksum, String checksumAlgorithm,
-                long objSize
-        ) throws NoSuchAlgorithmException, IOException, PidRefsFileExistsException,
-                RuntimeException, InterruptedException;
-
-        /**
-         * @see #storeObject(InputStream, String, String, String, String, long)
-         * 
-         *      Store an object and validate the given checksum & checksum algorithm.
-         */
-        public ObjectMetadata storeObject(
-                InputStream object, String pid, String checksum, String checksumAlgorithm
-        ) throws NoSuchAlgorithmException, IOException, PidRefsFileExistsException,
-                RuntimeException, InterruptedException;
-
-        /**
-         * @see #storeObject(InputStream, String, String, String, String, long)
-         * 
-         *      Store an object and generate an additional algorithm in hex digests.
-         */
-        public ObjectMetadata storeObject(
-                InputStream object, String pid, String additionalAlgorithm
-        ) throws NoSuchAlgorithmException, IOException, PidRefsFileExistsException,
-                RuntimeException, InterruptedException;
-
-        /**
-         * @see #storeObject(InputStream, String, String, String, String, long)
-         * 
-         *      Store an object and validate its size.
-         */
-        public ObjectMetadata storeObject(InputStream object, String pid, long objSize)
-                throws NoSuchAlgorithmException, IOException, PidRefsFileExistsException,
-                RuntimeException, InterruptedException;
-
-        /**
          * Creates references that allow objects stored in HashStore to be discoverable. Retrieving,
          * deleting or calculating a hex digest of an object is based on a pid argument; and to
          * proceed, we must be able to find the object associated with the pid.

--- a/src/main/java/org/dataone/hashstore/HashStoreClient.java
+++ b/src/main/java/org/dataone/hashstore/HashStoreClient.java
@@ -604,7 +604,7 @@ public class HashStoreClient {
 
                 // Store object
                 System.out.println("Storing object for guid: " + guid);
-                hashStore.storeObject(objStream, guid, checksum, algorithm);
+                hashStore.storeObject(objStream, guid, null, checksum, algorithm, -1);
 
             } catch (PidRefsFileExistsException poee) {
                 String errMsg = "Unexpected Error: " + poee.fillInStackTrace();

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -556,62 +556,6 @@ public class FileHashStore implements HashStore {
     }
 
 
-    /**
-     * Overload method for storeObject with size and a checksum & checksumAlgorithm.
-     */
-    @Override
-    public ObjectMetadata storeObject(
-        InputStream object, String pid, String checksum, String checksumAlgorithm, long objSize
-    ) throws NoSuchAlgorithmException, IOException, PidRefsFileExistsException, RuntimeException,
-        InterruptedException {
-        FileHashStoreUtility.ensureNotNull(checksum, "checksum", "storeObject");
-        FileHashStoreUtility.ensureNotNull(checksumAlgorithm, "checksumAlgorithm", "storeObject");
-        FileHashStoreUtility.checkNotNegativeOrZero(objSize, "storeObject");
-
-        return storeObject(object, pid, null, checksum, checksumAlgorithm, objSize);
-    }
-
-    /**
-     * Overload method for storeObject with just a checksum and checksumAlgorithm
-     */
-    @Override
-    public ObjectMetadata storeObject(
-        InputStream object, String pid, String checksum, String checksumAlgorithm
-    ) throws NoSuchAlgorithmException, IOException, PidRefsFileExistsException, RuntimeException,
-        InterruptedException {
-        FileHashStoreUtility.ensureNotNull(checksum, "checksum", "storeObject");
-        FileHashStoreUtility.ensureNotNull(checksumAlgorithm, "checksumAlgorithm", "storeObject");
-
-        return storeObject(object, pid, null, checksum, checksumAlgorithm, -1);
-    }
-
-    /**
-     * Overload method for storeObject with just the size of object to validate
-     */
-    @Override
-    public ObjectMetadata storeObject(InputStream object, String pid, long objSize)
-        throws NoSuchAlgorithmException, IOException, PidRefsFileExistsException, RuntimeException,
-        InterruptedException {
-        FileHashStoreUtility.checkNotNegativeOrZero(objSize, "storeObject");
-
-        return storeObject(object, pid, null, null, null, objSize);
-    }
-
-    /**
-     * Overload method for storeObject with an additionalAlgorithm
-     */
-    @Override
-    public ObjectMetadata storeObject(InputStream object, String pid, String additionalAlgorithm)
-        throws NoSuchAlgorithmException, IOException, PidRefsFileExistsException, RuntimeException,
-        InterruptedException {
-        FileHashStoreUtility.ensureNotNull(
-            additionalAlgorithm, "additionalAlgorithm", "storeObject"
-        );
-
-        return storeObject(object, pid, additionalAlgorithm, null, null, -1);
-    }
-
-
     @Override
     public void tagObject(String pid, String cid) throws IOException, PidRefsFileExistsException,
         NoSuchAlgorithmException, FileNotFoundException, InterruptedException {

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -39,7 +39,6 @@ import org.dataone.hashstore.exceptions.HashStoreRefsAlreadyExistException;
 import org.dataone.hashstore.exceptions.OrphanPidRefsFileException;
 import org.dataone.hashstore.exceptions.OrphanRefsFilesException;
 import org.dataone.hashstore.exceptions.PidNotFoundInCidRefsFileException;
-import org.dataone.hashstore.exceptions.PidRefsFileExistsException;
 import org.dataone.hashstore.filehashstore.FileHashStore.HashStoreIdTypes;
 import org.dataone.hashstore.testdata.TestDataHarness;
 import org.junit.jupiter.api.BeforeEach;
@@ -234,70 +233,6 @@ public class FileHashStoreInterfaceTest {
     }
 
     /**
-     * Verify that storeObject stores and validates a given checksum and its expected size
-     * with overloaded method
-     */
-    @Test
-    public void storeObject_overloadChecksumCsAlgoAndSize() throws Exception {
-        for (String pid : testData.pidList) {
-            String pidFormatted = pid.replace("/", "_");
-            Path testDataFile = testData.getTestFile(pidFormatted);
-            String md2 = testData.pidData.get(pid).get("md2");
-            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
-
-            InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(
-                dataStream, pid, md2, "MD2", objectSize
-            );
-            dataStream.close();
-
-            Map<String, String> hexDigests = objInfo.getHexDigests();
-
-            // Validate checksum values
-            assertEquals(md2, hexDigests.get("MD2"));
-        }
-    }
-
-    /**
-     * Verify that storeObject stores and validates a given checksum with overloaded method
-     */
-    @Test
-    public void storeObject_overloadChecksumAndChecksumAlgo() throws Exception {
-        for (String pid : testData.pidList) {
-            String pidFormatted = pid.replace("/", "_");
-            Path testDataFile = testData.getTestFile(pidFormatted);
-            String md2 = testData.pidData.get(pid).get("md2");
-
-            InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, md2, "MD2");
-            dataStream.close();
-
-            Map<String, String> hexDigests = objInfo.getHexDigests();
-
-            // Validate checksum values
-            assertEquals(md2, hexDigests.get("MD2"));
-        }
-    }
-
-    /**
-     * Check that store object returns the correct ObjectMetadata size with overloaded method
-     */
-    @Test
-    public void storeObject_overloadObjSize() throws Exception {
-        for (String pid : testData.pidList) {
-            String pidFormatted = pid.replace("/", "_");
-            Path testDataFile = testData.getTestFile(pidFormatted);
-
-            long objectSize = Long.parseLong(testData.pidData.get(pid).get("size"));
-            InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, objectSize);
-            dataStream.close();
-
-            assertEquals(objectSize, objInfo.getSize());
-        }
-    }
-
-    /**
      * Check that store object executes as expected with only an InputStream (does not create
      * any reference files)
      */
@@ -323,27 +258,6 @@ public class FileHashStoreInterfaceTest {
 
             Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
             assertFalse(Files.exists(cidRefsFilePath));
-        }
-    }
-
-    /**
-     * Verify that storeObject generates an additional checksum with overloaded method
-     */
-    @Test
-    public void storeObject_overloadAdditionalAlgo() throws Exception {
-        for (String pid : testData.pidList) {
-            String pidFormatted = pid.replace("/", "_");
-            Path testDataFile = testData.getTestFile(pidFormatted);
-
-            InputStream dataStream = Files.newInputStream(testDataFile);
-            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream, pid, "MD2");
-            dataStream.close();
-
-            Map<String, String> hexDigests = objInfo.getHexDigests();
-
-            // Validate checksum values
-            String md2 = testData.pidData.get(pid).get("md2");
-            assertEquals(md2, hexDigests.get("MD2"));
         }
     }
 


### PR DESCRIPTION
**Summary of Changes:**
- Removed unused `storeObject` overload methods, updated junit tests and `HashStore` interface
- Fixed `HashStoreClient` error (was calling an overload method)