### PR TITLE
Feature-80: 'verifyObject' Signature Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To create or interact with a HashStore, instantiate a HashStore object with the 
 - storeAlgorithm
 - storeMetadataNamespace
 
-```java
+```
 String classPackage = "org.dataone.hashstore.filehashstore.FileHashStore";
 Path rootDirectory = tempFolder.resolve("metacat");
 
@@ -70,7 +70,7 @@ hashStore.storeObject(stream, pid)
 In HashStore, objects are first saved as temporary files while their content identifiers are calculated. Once the default hash algorithm list and their hashes are generated, objects are stored in their permanent location using the store's algorithm's corresponding hash value, the store depth and the store width. Lastly, reference files are created for the object so that they can be found and retrieved given an identifier (ex. persistent identifier (pid)). Note: Objects are also stored once and only once.
 
 By calling the various interface methods for  `storeObject`, the calling app/client can validate, store and tag an object simultaneously if the relevant data is available. In the absence of an identifier (ex. persistent identifier (pid)), `storeObject` can be called to solely store an object. The client is then expected to call `verifyObject` when the relevant metadata is available to confirm that the object has been stored as expected. And to finalize the process (to make the object discoverable), the client calls `tagObject``. In summary, there are two expected paths to store an object:
-```java
+```
 // All-in-one process which stores, validates and tags an object
 objectMetadata objInfo = storeObject(InputStream, pid, additionalAlgorithm, checksum, checksumAlgorithm, objSize)
 
@@ -78,7 +78,7 @@ objectMetadata objInfo = storeObject(InputStream, pid, additionalAlgorithm, chec
 // Store object
 objectMetadata objInfo = storeObject(InputStream)
 // Validate object, returns False if there is a mismatch and deletes the associated file
-verifyObject(objInfo, checksum, checksumAlgorithn, objSize)
+verifyObject(objInfo, checksum, checksumAlgorithn, objSize, true)
 // Tag object, makes the object discoverable (find, retrieve, delete)
 tagObject(pid, cid)
 ```

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -117,6 +117,10 @@ public interface HashStore {
          * @throws NonMatchingObjSizeException       Given size =/= objMeta size value
          * @throws NonMatchingChecksumException      Given checksum =/= objMeta checksum value
          * @throws UnsupportedHashAlgorithmException Given algo is not found or supported
+         * @throws NoSuchAlgorithmException          When 'deleteInvalidObject' is true and an algo
+         *                                           used to get a cid refs file is not supported
+         * @throws InterruptedException              When 'deleteInvalidObject' is true and an issue
+         *                                           with coordinating deleting objects occurs
          * @throws IOException                       Issue with recalculating supported algo for
          *                                           checksum not found
          */
@@ -124,7 +128,8 @@ public interface HashStore {
             ObjectMetadata objectInfo, String checksum, String checksumAlgorithm, long objSize,
             boolean deleteInvalidObject)
             throws NonMatchingObjSizeException, NonMatchingChecksumException,
-            UnsupportedHashAlgorithmException, IOException;
+            UnsupportedHashAlgorithmException, InterruptedException, NoSuchAlgorithmException,
+            IOException;
 
         /**
          * Checks whether an object referenced by a pid exists and returns a map containing the

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -108,18 +108,22 @@ public interface HashStore {
          * Confirms that an ObjectMetadata's content is equal to the given values. If it is not
          * equal, it will return False - otherwise True.
          *
-         * @param objectInfo        ObjectMetadata object with values
-         * @param checksum          Value of checksum to validate against
-         * @param checksumAlgorithm Algorithm of checksum submitted
-         * @param objSize           Expected size of object to validate after storing
+         * @param objectInfo          ObjectMetadata object with values
+         * @param checksum            Value of checksum to validate against
+         * @param checksumAlgorithm   Algorithm of checksum submitted
+         * @param objSize             Expected size of object to validate after storing
+         * @param deleteInvalidObject If true, HashStore will attempt to remove the data object
+         *                            given to verify
          * @throws NonMatchingObjSizeException       Given size =/= objMeta size value
          * @throws NonMatchingChecksumException      Given checksum =/= objMeta checksum value
          * @throws UnsupportedHashAlgorithmException Given algo is not found or supported
-         * @throws IOException Issue with recalculating supported algo for checksum not found
+         * @throws IOException                       Issue with recalculating supported algo for
+         *                                           checksum not found
          */
         public void verifyObject(
-                ObjectMetadata objectInfo, String checksum, String checksumAlgorithm, long objSize
-        ) throws NonMatchingObjSizeException, NonMatchingChecksumException,
+            ObjectMetadata objectInfo, String checksum, String checksumAlgorithm, long objSize,
+            boolean deleteInvalidObject)
+            throws NonMatchingObjSizeException, NonMatchingChecksumException,
             UnsupportedHashAlgorithmException, IOException;
 
         /**

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -224,34 +224,17 @@ public interface HashStore {
                 FileNotFoundException, IOException, NoSuchAlgorithmException;
 
         /**
-         * Deletes an object and its related data permanently from HashStore using a given
-         * persistent identifier. If the `idType` is 'pid', the object associated with the pid will
-         * be deleted if it is not referenced by any other pids, along with its reference files and
-         * all metadata documents found in its respective metadata directory. If the `idType` is
-         * 'cid', only the object will be deleted if it is not referenced by other pids.
+         * Deletes an object and all relevant associated files (ex. system metadata, reference
+         * files, etc.) based on a given pid. If other pids still reference the pid's associated
+         * object, the object will not be deleted.
          * 
-         * Notes: All objects are renamed at their existing path with a '_deleted' appended
-         * to their file name before they are deleted.
-         * 
-         * @param idType 'pid' or 'cid'
-         * @param id     Authority-based identifier or content identifier
+         * @param pid Authority-based identifier
          * @throws IllegalArgumentException When pid is null or empty
          * @throws IOException              I/O error when deleting empty directories,
          *                                  modifying/deleting reference files
          * @throws NoSuchAlgorithmException When algorithm used to calculate an object or metadata's
          *                                  address is not supported
          * @throws InterruptedException     When deletion synchronization is interrupted
-         */
-        public void deleteObject(String idType, String id) throws IllegalArgumentException,
-                IOException, NoSuchAlgorithmException, InterruptedException;
-
-        /**
-         * Deletes an object and all relevant associated files (ex. system metadata, reference
-         * files, etc.) based on a given pid. If other pids still reference the pid's associated
-         * object, the object will not be deleted.
-         * 
-         * @param pid Authority-based identifier
-         * @see #deleteObject(String, String) for more details.
          */
         public void deleteObject(String pid) throws IllegalArgumentException, IOException,
                 NoSuchAlgorithmException, InterruptedException;

--- a/src/main/java/org/dataone/hashstore/HashStore.java
+++ b/src/main/java/org/dataone/hashstore/HashStore.java
@@ -125,9 +125,10 @@ public interface HashStore {
         /**
          * Checks whether an object referenced by a pid exists and returns a map containing the
          * absolute path to the object, pid refs file, cid refs file and sysmeta document.
-         * 
+         *
          * @param pid Authority-based identifier
-         * @return Content identifier (cid)
+         * @return Map containing the following keys: cid, cid_object_path, cid_refs_path,
+         * pid_refs_path, sysmeta_path
          * @throws NoSuchAlgorithmException          When algorithm used to calculate pid refs
          *                                           file's absolute address is not valid
          * @throws IOException                       Unable to read from a pid refs file or pid refs

--- a/src/main/java/org/dataone/hashstore/HashStoreClient.java
+++ b/src/main/java/org/dataone/hashstore/HashStoreClient.java
@@ -21,7 +21,6 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 
 import org.dataone.hashstore.filehashstore.FileHashStoreUtility;
-import org.dataone.hashstore.filehashstore.FileHashStore.HashStoreIdTypes;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -245,8 +244,7 @@ public class HashStoreClient {
                     String pid = cmd.getOptionValue("pid");
                     FileHashStoreUtility.ensureNotNull(pid, "-pid", "HashStoreClient");
 
-                    String deleteIdType = HashStoreIdTypes.pid.getName();
-                    hashStore.deleteObject(deleteIdType, pid);
+                    hashStore.deleteObject(pid);
                     System.out.println("Object for pid (" + pid + ") has been deleted.");
 
                 } else if (cmd.hasOption("deletemetadata")) {
@@ -718,8 +716,7 @@ public class HashStoreClient {
 
                 // Delete object
                 System.out.println("Deleting object for guid: " + guid);
-                String deleteIdType = HashStoreIdTypes.pid.getName();
-                hashStore.deleteObject(deleteIdType, guid);
+                hashStore.deleteObject(guid);
 
             } catch (FileNotFoundException fnfe) {
                 String errMsg = "Unexpected Error: " + fnfe.fillInStackTrace();

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1579,7 +1579,6 @@ public class FileHashStore implements HashStore {
      * @param objSize           Expected size of object
      * @param storedObjFileSize Actual size of object stored
      * @throws NoSuchAlgorithmException If algorithm requested to validate against is absent
-     * @throws IOException              Issue with deleting tmpFile
      */
     private void validateTmpObject(
         boolean requestValidation, String checksum, String checksumAlgorithm, Path tmpFile,

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -2322,39 +2322,38 @@ public class FileHashStore implements HashStore {
     /**
      * Get the absolute path of a HashStore object, metadata or refs file
      *
-     * @param abpcId     Authority-based, persistent or content identifier
-     * @param entity   "object", "metadata" or "refs"
-     * @param formatId Metadata namespace or reference type (pid/cid)
+     * @param abpcId Authority-based, persistent or content identifier
+     * @param entity "object", "metadata" or "refs"
+     * @param detail Metadata namespace, ref type (pid/cid) or other value
      * @return Actual path to object
      * @throws IllegalArgumentException If entity is not object or metadata
      * @throws NoSuchAlgorithmException If store algorithm is not supported
      * @throws IOException              If unable to retrieve cid
      */
-    protected Path getExpectedPath(String abpcId, String entity, String formatId)
+    protected Path getExpectedPath(String abpcId, String entity, String detail)
         throws IllegalArgumentException, NoSuchAlgorithmException, IOException {
-        Path realPath;
         if (entity.equalsIgnoreCase("object")) {
-            realPath = getHashStoreDataObject(abpcId);
+            return getHashStoreDataObjectPath(abpcId);
         } else if (entity.equalsIgnoreCase("metadata")) {
-            realPath = getHashStoreMetadataPath(abpcId, formatId);
+            return getHashStoreMetadataPath(abpcId, detail);
         } else if (entity.equalsIgnoreCase("refs")) {
-            realPath = getHashStoreRefsPath(abpcId, formatId);
+            return getHashStoreRefsPath(abpcId, detail);
         } else {
             throw new IllegalArgumentException(
-                "FileHashStore.getExpectedPath - entity must be 'object', 'metadata' or 'refs'"
-            );
+                "FileHashStore.getExpectedPath - entity must be 'object', 'metadata' or 'refs'");
         }
-        return realPath;
     }
 
     /**
      * Get the absolute path to a HashStore data object
+     *
      * @param abpId Authority-based or persistent identifier
      * @return Path to the HasHStore data object
      * @throws NoSuchAlgorithmException When an algorithm used to calculate a hash is not supported
      * @throws IOException Issue when reading a pid refs file to retrieve a 'cid'
      */
-    private Path getHashStoreDataObject(String abpId) throws NoSuchAlgorithmException, IOException {
+    protected Path getHashStoreDataObjectPath(String abpId) throws NoSuchAlgorithmException,
+        IOException {
         String hashedId = FileHashStoreUtility.getPidHexDigest(abpId, OBJECT_STORE_ALGORITHM);
         // `hashId` here is used to calculate the address of the pid refs file
         String pidRefsFileRelativePath = FileHashStoreUtility.getHierarchicalPathString(
@@ -2365,8 +2364,9 @@ public class FileHashStore implements HashStore {
         String objectCid;
         if (!Files.exists(pathToPidRefsFile)) {
             String errMsg =
-                "FileHashStore.getExpectedPath - Pid Refs file does not exist for pid: " + abpId
-                    + " with object address: " + pathToPidRefsFile + ". Cannot retrieve cid.";
+                "FileHashStore.getHashStoreDataObjectPath - Pid Refs file does not exist for pid: "
+                    + abpId + " with object address: " + pathToPidRefsFile + ". Cannot retrieve "
+                    + "cid.";
             logFileHashStore.warn(errMsg);
             throw new FileNotFoundException(errMsg);
         } else {
@@ -2382,12 +2382,14 @@ public class FileHashStore implements HashStore {
 
     /**
      * Get the absolute path to a HashStore metadata document
+     *
      * @param abpId Authority-based or persistent identifier
      * @param formatId Metadata formatId or namespace
      * @return Path to the requested metadata document
      * @throws NoSuchAlgorithmException When an algorithm used to calculate a hash is not supported
      */
-    private Path getHashStoreMetadataPath(String abpId, String formatId) throws NoSuchAlgorithmException {
+    protected Path getHashStoreMetadataPath(String abpId, String formatId)
+        throws NoSuchAlgorithmException {
         // Get the pid metadata directory (the sharded path of the hashId)
         String hashId = FileHashStoreUtility.getPidHexDigest(abpId, OBJECT_STORE_ALGORITHM);
         String pidMetadataDirRelPath = FileHashStoreUtility.getHierarchicalPathString(
@@ -2404,12 +2406,14 @@ public class FileHashStore implements HashStore {
 
     /**
      * Get the absolute path to a HashStore pid or cid ref file
+     *
      * @param abpcId Authority-based identifier, persistent identifier or content identifier
      * @param refType "cid" or "pid
      * @return Path to the requested refs file
      * @throws NoSuchAlgorithmException When an algorithm used to calculate a hash is not supported
      */
-    private Path getHashStoreRefsPath(String abpcId, String refType) throws NoSuchAlgorithmException {
+    protected Path getHashStoreRefsPath(String abpcId, String refType)
+        throws NoSuchAlgorithmException {
         Path realPath;
         if (refType.equalsIgnoreCase(HashStoreIdTypes.pid.getName())) {
             String hashedId = FileHashStoreUtility.getPidHexDigest(abpcId, OBJECT_STORE_ALGORITHM);
@@ -2424,7 +2428,8 @@ public class FileHashStore implements HashStore {
             realPath = REFS_CID_FILE_DIRECTORY.resolve(cidRelativePath);
         } else {
             String errMsg =
-                "FileHashStore.getExpectedPath - formatId must be 'pid' or 'cid' when entity is 'refs'";
+                "FileHashStore.getHashStoreRefsPath - formatId must be 'pid' or 'cid' when entity"
+                    + " is 'refs'";
             logFileHashStore.error(errMsg);
             throw new IllegalArgumentException(errMsg);
         }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -2357,18 +2357,7 @@ public class FileHashStore implements HashStore {
             );
             realPath = OBJECT_STORE_DIRECTORY.resolve(objRelativePath);
         } else if (entity.equalsIgnoreCase("metadata")) {
-            String hashId = FileHashStoreUtility.getPidHexDigest(abId, OBJECT_STORE_ALGORITHM);
-            // Get the pid metadata directory (the sharded path of the hashId)
-            String pidMetadataDirRelPath = FileHashStoreUtility.getHierarchicalPathString(
-                DIRECTORY_DEPTH, DIRECTORY_WIDTH, hashId
-            );
-            // The file name for the metadata document is the hash of the supplied 'pid + 'formatId'
-            String metadataDocHash =
-                FileHashStoreUtility.getPidHexDigest(abId + formatId, OBJECT_STORE_ALGORITHM);
-            realPath = METADATA_STORE_DIRECTORY.resolve(pidMetadataDirRelPath).resolve(
-                metadataDocHash
-            );
-
+            realPath = getHashStoreMetadataPath(abId, formatId);
         } else if (entity.equalsIgnoreCase("refs")) {
             realPath = getHashStoreRefsPath(abId, formatId);
         } else {
@@ -2377,6 +2366,28 @@ public class FileHashStore implements HashStore {
             );
         }
         return realPath;
+    }
+
+    /**
+     * Get the absolute path to a HashStore metadata document
+     * @param abpId Authority-based or persistent identifier
+     * @param formatId Metadata formatId or namespace
+     * @return Path to the requested metadata document
+     * @throws NoSuchAlgorithmException When an algorithm used to calculate a hash is not supported
+     */
+    private Path getHashStoreMetadataPath(String abpId, String formatId) throws NoSuchAlgorithmException {
+        // Get the pid metadata directory (the sharded path of the hashId)
+        String hashId = FileHashStoreUtility.getPidHexDigest(abpId, OBJECT_STORE_ALGORITHM);
+        String pidMetadataDirRelPath = FileHashStoreUtility.getHierarchicalPathString(
+            DIRECTORY_DEPTH, DIRECTORY_WIDTH, hashId
+        );
+        // The file name for the metadata document is the hash of the supplied 'pid + 'formatId'
+        String metadataDocHash =
+            FileHashStoreUtility.getPidHexDigest(abpId + formatId, OBJECT_STORE_ALGORITHM);
+        // Real path to metadata doc
+        return METADATA_STORE_DIRECTORY.resolve(pidMetadataDirRelPath).resolve(
+            metadataDocHash
+        );
     }
 
     /**

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -685,7 +685,8 @@ public class FileHashStore implements HashStore {
 
     @Override
     public void verifyObject(
-        ObjectMetadata objectInfo, String checksum, String checksumAlgorithm, long objSize
+        ObjectMetadata objectInfo, String checksum, String checksumAlgorithm, long objSize,
+        boolean deleteInvalidObject
     ) throws NonMatchingObjSizeException, NonMatchingChecksumException,
         UnsupportedHashAlgorithmException, IOException {
         logFileHashStore.debug(

--- a/src/test/java/org/dataone/hashstore/HashStoreRunnable.java
+++ b/src/test/java/org/dataone/hashstore/HashStoreRunnable.java
@@ -57,7 +57,7 @@ public class HashStoreRunnable implements Runnable {
                     break;
                 case deleteObject:
                     try {
-                        hashstore.deleteObject("pid", pid);
+                        hashstore.deleteObject(pid);
                     } catch (Exception e) {
                         throw new HashStoreServiceException(e.getMessage());
                     }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -290,7 +290,7 @@ public class FileHashStoreInterfaceTest {
                 fileHashStore.findObject(pid);
             });
 
-            Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+            Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cid, "cid");
             assertFalse(Files.exists(cidRefsFilePath));
         }
     }
@@ -310,7 +310,7 @@ public class FileHashStoreInterfaceTest {
         fileHashStore.storeObject(dataStream, pid, null, checksumCorrect, "SHA-256", -1);
         dataStream.close();
 
-        Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
+        Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
         assertTrue(Files.exists(objCidAbsPath));
     }
 
@@ -468,7 +468,7 @@ public class FileHashStoreInterfaceTest {
             dataStreamDup.close();
 
             String cid = objInfo.getCid();
-            Path absCidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+            Path absCidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
             assertTrue(fileHashStore.isStringInRefsFile(pid, absCidRefsPath));
             assertTrue(fileHashStore.isStringInRefsFile(pidTwo, absCidRefsPath));
         }
@@ -504,7 +504,7 @@ public class FileHashStoreInterfaceTest {
         fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
         dataStream.close();
 
-        Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
+        Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
         assertTrue(Files.exists(objCidAbsPath));
 
     }
@@ -586,9 +586,9 @@ public class FileHashStoreInterfaceTest {
                 dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
-                    Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
-                    Path pidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
-                    Path cidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+                    Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
+                    Path pidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
+                    Path cidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
                     assertTrue(Files.exists(objCidAbsPath));
                     assertTrue(Files.exists(pidRefsPath));
                     assertTrue(Files.exists(cidRefsPath));
@@ -607,9 +607,9 @@ public class FileHashStoreInterfaceTest {
                 dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
-                    Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
-                    Path pidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
-                    Path cidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+                    Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
+                    Path pidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
+                    Path cidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
                     assertTrue(Files.exists(objCidAbsPath));
                     assertTrue(Files.exists(pidRefsPath));
                     assertTrue(Files.exists(cidRefsPath));
@@ -628,9 +628,9 @@ public class FileHashStoreInterfaceTest {
                 dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
-                    Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
-                    Path pidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
-                    Path cidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+                    Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
+                    Path pidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
+                    Path cidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
                     assertTrue(Files.exists(objCidAbsPath));
                     assertTrue(Files.exists(pidRefsPath));
                     assertTrue(Files.exists(cidRefsPath));
@@ -649,9 +649,9 @@ public class FileHashStoreInterfaceTest {
                 dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
-                    Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
-                    Path pidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
-                    Path cidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+                    Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
+                    Path pidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
+                    Path cidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
                     assertTrue(Files.exists(objCidAbsPath));
                     assertTrue(Files.exists(pidRefsPath));
                     assertTrue(Files.exists(cidRefsPath));
@@ -670,9 +670,9 @@ public class FileHashStoreInterfaceTest {
                 dataStream.close();
                 if (objInfo != null) {
                     String cid = objInfo.getCid();
-                    Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
-                    Path pidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
-                    Path cidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+                    Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
+                    Path pidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
+                    Path cidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
                     assertTrue(Files.exists(objCidAbsPath));
                     assertTrue(Files.exists(pidRefsPath));
                     assertTrue(Files.exists(cidRefsPath));
@@ -722,7 +722,7 @@ public class FileHashStoreInterfaceTest {
 
         // Check cid refs file that every pid is found
         String cidSha256DigestFromTestData = testData.pidData.get(pid).get("sha256");
-        Path cidRefsFilePath = fileHashStore.getExpectedPath(cidSha256DigestFromTestData, "refs", "cid");
+        Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cidSha256DigestFromTestData, "cid");
         Set<String> stringSet = new HashSet<>(pidModifiedList);
         List<String> lines = Files.readAllLines(cidRefsFilePath);
         boolean allFoundPidsFound = true;
@@ -758,9 +758,8 @@ public class FileHashStoreInterfaceTest {
             metadataStream.close();
 
             // Calculate absolute path
-            Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
-                pid, "metadata", testFormatId
-            );
+            Path metadataPidExpectedPath =
+                fileHashStore.getHashStoreMetadataPath(pid, testFormatId);
 
             assertEquals(metadataPidExpectedPath.toString(), metadataPath);
             assertTrue(Files.exists(metadataPidExpectedPath));
@@ -784,9 +783,8 @@ public class FileHashStoreInterfaceTest {
 
             // Calculate absolute path
             String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
-            Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
-                pid, "metadata", storeMetadataNamespace
-            );
+            Path metadataPidExpectedPath =
+                fileHashStore.getHashStoreMetadataPath(pid, storeMetadataNamespace);
 
             assertEquals(metadataPidExpectedPath.toString(), metadataPath);
             assertTrue(Files.exists(metadataPidExpectedPath));
@@ -844,13 +842,11 @@ public class FileHashStoreInterfaceTest {
             metadataStreamDup.close();
 
             // Calculate absolute path
-            Path metadataTestFormatIdExpectedPath = fileHashStore.getExpectedPath(
-                pid, "metadata", testFormatId
-            );
+            Path metadataTestFormatIdExpectedPath =
+                fileHashStore.getHashStoreMetadataPath(pid, testFormatId);
             String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
-            Path metadataDefaultExpectedPath = fileHashStore.getExpectedPath(
-                pid, "metadata", storeMetadataNamespace
-            );
+            Path metadataDefaultExpectedPath =
+                fileHashStore.getHashStoreMetadataPath(pid, storeMetadataNamespace);
 
             assertEquals(metadataTestFormatIdExpectedPath.toString(), metadataPath);
             assertTrue(Files.exists(metadataTestFormatIdExpectedPath));
@@ -982,9 +978,8 @@ public class FileHashStoreInterfaceTest {
                 metadataStream.close();
                 // Calculate absolute path
                 String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
-                Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
-                    pid, "metadata", storeMetadataNamespace
-                );
+                Path metadataPidExpectedPath =
+                    fileHashStore.getHashStoreMetadataPath(pid, storeMetadataNamespace);
                 assertEquals(metadataPath, metadataPidExpectedPath.toString());
             } catch (IOException | NoSuchAlgorithmException | InterruptedException e) {
                 e.printStackTrace();
@@ -998,9 +993,8 @@ public class FileHashStoreInterfaceTest {
                 metadataStream.close();
                 // Calculate absolute path
                 String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
-                Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
-                    pid, "metadata", storeMetadataNamespace
-                );
+                Path metadataPidExpectedPath =
+                    fileHashStore.getHashStoreMetadataPath(pid, storeMetadataNamespace);
                 assertEquals(metadataPath, metadataPidExpectedPath.toString());
             } catch (Exception e) {
                 e.printStackTrace();
@@ -1014,9 +1008,8 @@ public class FileHashStoreInterfaceTest {
                 metadataStream.close();
                 // Calculate absolute path
                 String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
-                Path metadataPidExpectedPath = fileHashStore.getExpectedPath(
-                    pid, "metadata", storeMetadataNamespace
-                );
+                Path metadataPidExpectedPath =
+                    fileHashStore.getHashStoreMetadataPath(pid, storeMetadataNamespace);
                 assertEquals(metadataPath, metadataPidExpectedPath.toString());
             } catch (Exception e) {
                 e.printStackTrace();
@@ -1034,7 +1027,7 @@ public class FileHashStoreInterfaceTest {
         // Confirm metadata file is written
         Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
         String formatId = fhsProperties.getProperty("storeMetadataNamespace");
-        Path metadataCidAbsPath = fileHashStore.getExpectedPath(pid, "metadata", formatId);
+        Path metadataCidAbsPath = fileHashStore.getHashStoreMetadataPath(pid, formatId);
         assertTrue(Files.exists(metadataCidAbsPath));
 
         // Confirm there are only three files in HashStore - 'hashstore.yaml', the metadata file written
@@ -1393,7 +1386,7 @@ public class FileHashStoreInterfaceTest {
             metadataStream.close();
             InputStream metadataStreamTwo = Files.newInputStream(testMetaDataFile);
             String metadataDefaultPathString = fileHashStore.storeMetadata(metadataStreamTwo, pid);
-            Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
+            Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
             Path metadataPath = Paths.get(metadataPathString);
             Path metadataDefaultPath = Paths.get(metadataDefaultPathString);
             metadataStreamTwo.close();
@@ -1428,7 +1421,7 @@ public class FileHashStoreInterfaceTest {
             dataStream.close();
 
             // Get metadata file
-            Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
+            Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
 
             // Confirm expected documents exist
             assertTrue(Files.exists(objCidAbsPath));
@@ -1454,7 +1447,7 @@ public class FileHashStoreInterfaceTest {
             fileHashStore.storeObject(dataStream, pid, null, null, null, -1);
             dataStream.close();
 
-            Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
+            Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
             fileHashStore.deleteObject(fhsDeleteTypePid, pid);
 
             // Check that file doesn't exist
@@ -1487,8 +1480,8 @@ public class FileHashStoreInterfaceTest {
             String cid = objInfo.getCid();
 
             // Path objAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
-            Path absPathPidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
-            Path absPathCidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+            Path absPathPidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
+            Path absPathCidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
             fileHashStore.deleteObject(fhsDeleteTypePid, pid);
             assertFalse(Files.exists(absPathPidRefsPath));
             assertFalse(Files.exists(absPathCidRefsPath));
@@ -1515,9 +1508,9 @@ public class FileHashStoreInterfaceTest {
             String cid = objInfo.getCid();
             fileHashStore.tagObject(pidExtra, cid);
 
-            Path objCidAbsPath = fileHashStore.getExpectedPath(pid, "object", null);
-            Path absPathPidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
-            Path absPathCidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+            Path objCidAbsPath = fileHashStore.getHashStoreDataObjectPath(pid);
+            Path absPathPidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
+            Path absPathCidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
             fileHashStore.deleteObject(fhsDeleteTypePid, pid);
 
             assertFalse(Files.exists(absPathPidRefsPath));
@@ -1543,10 +1536,10 @@ public class FileHashStoreInterfaceTest {
             dataStream.close();
             String cid = objInfo.getCid();
             String pidExtra = "dou.test" + pid;
-            Path objRealPath = fileHashStore.getExpectedPath(pid, "object", null);
+            Path objRealPath = fileHashStore.getHashStoreDataObjectPath(pid);
 
             // Manually change the pid found in the cid refs file
-            Path absPathCidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+            Path absPathCidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
             fileHashStore.updateRefsFile(pidExtra, absPathCidRefsPath, "add");
             // Create an orphaned pid refs file
             fileHashStore.updateRefsFile(pid, absPathCidRefsPath, "remove");
@@ -1556,7 +1549,7 @@ public class FileHashStoreInterfaceTest {
             // Confirm cid refs file still exists
             assertTrue(Files.exists(absPathCidRefsPath));
             // Confirm the original (and now orphaned) pid refs file is deleted
-            Path absPathPidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
+            Path absPathPidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
             assertFalse(Files.exists(absPathPidRefsPath));
             // Confirm the object has not been deleted
             assertTrue(Files.exists(objRealPath));
@@ -1618,8 +1611,8 @@ public class FileHashStoreInterfaceTest {
         String cid = "abcdef123456789";
         fileHashStore.tagObject(pid, cid);
 
-        Path absPathCidRefsPath = fileHashStore.getExpectedPath(pid, "refs", "pid");
-        Path absPathPidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path absPathCidRefsPath = fileHashStore.getHashStoreRefsPath(pid, "pid");
+        Path absPathPidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
 
         fileHashStore.deleteObject("pid", pid);
         assertFalse(Files.exists(absPathCidRefsPath));
@@ -1674,10 +1667,10 @@ public class FileHashStoreInterfaceTest {
             fileHashStore.deleteObject(fhsDeleteTypeCid, cid);
 
             // Get permanent address of the actual cid
-            Path objRealPath = fileHashStore.getExpectedPath(pid, "object", null);
+            Path objRealPath = fileHashStore.getHashStoreDataObjectPath(pid);
             assertTrue(Files.exists(objRealPath));
             // Confirm cid refs file still exists
-            Path cidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+            Path cidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
             assertTrue(Files.exists(cidRefsPath));
         }
     }
@@ -1748,7 +1741,7 @@ public class FileHashStoreInterfaceTest {
             fileHashStore.deleteMetadata(pid, storeFormatId);
 
             // Check that file doesn't exist
-            Path metadataCidPath = fileHashStore.getExpectedPath(pid, "metadata", storeFormatId);
+            Path metadataCidPath = fileHashStore.getHashStoreMetadataPath(pid, storeFormatId);
             assertFalse(Files.exists(metadataCidPath));
 
             // Check that parent directories are not deleted
@@ -1789,11 +1782,9 @@ public class FileHashStoreInterfaceTest {
 
             // Check that file doesn't exist
             String storeFormatId = (String) fhsProperties.get("storeMetadataNamespace");
-            Path metadataCidPath = fileHashStore.getExpectedPath(pid, "metadata", storeFormatId);
-            Path metadataCidPathTwo = fileHashStore.getExpectedPath(pid, "metadata", formatIdTwo);
-            Path metadataCidPathThree = fileHashStore.getExpectedPath(
-                pid, "metadata", formatIdThree
-            );
+            Path metadataCidPath = fileHashStore.getHashStoreMetadataPath(pid, storeFormatId);
+            Path metadataCidPathTwo = fileHashStore.getHashStoreMetadataPath(pid, formatIdTwo);
+            Path metadataCidPathThree = fileHashStore.getHashStoreMetadataPath(pid, formatIdThree);
 
             assertFalse(Files.exists(metadataCidPath));
             assertFalse(Files.exists(metadataCidPathTwo));
@@ -2041,8 +2032,8 @@ public class FileHashStoreInterfaceTest {
             String cidRefsPath = objInfoMap.get("cid_refs_path");
             String pidRefsPath = objInfoMap.get("pid_refs_path");
 
-            Path cidRefsFilePath = fileHashStore.getExpectedPath(objInfo.getCid(), "refs", "cid");
-            Path pidRefsFilePath = fileHashStore.getExpectedPath(pid, "refs", "pid");
+            Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(objInfo.getCid(), "cid");
+            Path pidRefsFilePath = fileHashStore.getHashStoreRefsPath(pid, "pid");
 
             assertEquals(cidRefsPath, cidRefsFilePath.toString());
             assertEquals(pidRefsPath, pidRefsFilePath.toString());
@@ -2077,9 +2068,7 @@ public class FileHashStoreInterfaceTest {
             String objInfoSysmetaPath = objInfoMap.get("sysmeta_path");
 
             String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
-            Path sysmetaPath = fileHashStore.getExpectedPath(
-                pid, "metadata", storeMetadataNamespace
-            );
+            Path sysmetaPath = fileHashStore.getHashStoreMetadataPath(pid, storeMetadataNamespace);
             System.out.println(sysmetaPath);
 
             assertEquals(objInfoSysmetaPath, sysmetaPath.toString());
@@ -2104,11 +2093,6 @@ public class FileHashStoreInterfaceTest {
 
             Map<String, String> objInfoMap = fileHashStore.findObject(pid);
             String objInfoSysmetaPath = objInfoMap.get("sysmeta_path");
-
-            String storeMetadataNamespace = fhsProperties.getProperty("storeMetadataNamespace");
-            Path sysmetaPath = fileHashStore.getExpectedPath(
-                pid, "metadata", storeMetadataNamespace
-            );
 
             assertEquals(objInfoSysmetaPath, "Does not exist");
         }
@@ -2139,7 +2123,7 @@ public class FileHashStoreInterfaceTest {
         String cid = "abcdef123456789";
         fileHashStore.tagObject(pid, cid);
 
-        Path cidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
         Files.delete(cidRefsPath);
 
         assertThrows(OrphanPidRefsFileException.class, () -> {
@@ -2158,7 +2142,7 @@ public class FileHashStoreInterfaceTest {
         String cid = "abcdef123456789";
         fileHashStore.tagObject(pid, cid);
 
-        Path cidRefsPath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsPath = fileHashStore.getHashStoreRefsPath(cid, "cid");
         fileHashStore.updateRefsFile(pid, cidRefsPath, "remove");
 
         assertThrows(PidNotFoundInCidRefsFileException.class, () -> {

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -101,7 +101,7 @@ public class FileHashStoreReferencesTest {
         String cid = "abcdef123456789";
         fileHashStore.tagObject(pid, cid);
 
-        Path pidRefsFilePath = fileHashStore.getExpectedPath(pid, "refs", "pid");
+        Path pidRefsFilePath = fileHashStore.getHashStoreRefsPath(pid, "pid");
         assertTrue(Files.exists(pidRefsFilePath));
 
         String retrievedCid = new String(Files.readAllBytes(pidRefsFilePath));
@@ -117,7 +117,7 @@ public class FileHashStoreReferencesTest {
         String cid = "abcdef123456789";
         fileHashStore.tagObject(pid, cid);
 
-        Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cid, "cid");
         assertTrue(Files.exists(cidRefsFilePath));
 
         String retrievedPid = new String(Files.readAllBytes(cidRefsFilePath));
@@ -177,9 +177,8 @@ public class FileHashStoreReferencesTest {
         String cidForOrphanPidRef = "987654321fedcba";
 
         // Create orphaned pid refs file
-        Path absPidRefsPath = fileHashStore.getExpectedPath(
-            pid, "refs", HashStoreIdTypes.pid.getName()
-        );
+        Path absPidRefsPath =
+            fileHashStore.getHashStoreRefsPath(pid, HashStoreIdTypes.pid.getName());
         File pidRefsTmpFile = fileHashStore.writeRefsFile(
             cidForOrphanPidRef, HashStoreIdTypes.pid.getName()
         );
@@ -204,7 +203,7 @@ public class FileHashStoreReferencesTest {
         String cid = "abcdef123456789";
         fileHashStore.tagObject(pid, cid);
         // Manually delete the cid refs file
-        Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cid, "cid");
         Files.delete(cidRefsFilePath);
 
         fileHashStore.tagObject(pid, cid);
@@ -230,13 +229,11 @@ public class FileHashStoreReferencesTest {
         fileHashStore.tagObject(pidAdditional, cid);
 
         // Confirm missing pid refs file has been created
-        Path pidAdditionalRefsFilePath = fileHashStore.getExpectedPath(
-            pidAdditional, "refs", "pid"
-        );
+        Path pidAdditionalRefsFilePath = fileHashStore.getHashStoreRefsPath(pidAdditional, "pid");
         assertTrue(Files.exists(pidAdditionalRefsFilePath));
 
         // Check cid refs file
-        Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cid, "cid");
         boolean pidFoundInCidRefFiles = fileHashStore.isStringInRefsFile(
             pidAdditional, cidRefsFilePath
         );
@@ -278,7 +275,7 @@ public class FileHashStoreReferencesTest {
         Path pidRefsTmpFilePath = pidRefsTmpFile.toPath();
 
         // Get path of the cid refs file
-        Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cid, "cid");
 
         assertThrows(CidNotFoundInPidRefsFileException.class, () -> {
             fileHashStore.verifyHashStoreRefsFiles(pid, cid, pidRefsTmpFilePath, cidRefsFilePath);
@@ -300,7 +297,7 @@ public class FileHashStoreReferencesTest {
         Path cidRefsTmpFilePath = cidRefsTmpFile.toPath();
 
         // Get path of the pid refs file
-        Path pidRefsFilePath = fileHashStore.getExpectedPath(pid, "refs", "pid");
+        Path pidRefsFilePath = fileHashStore.getHashStoreRefsPath(pid, "pid");
 
         assertThrows(PidNotFoundInCidRefsFileException.class, () -> {
             fileHashStore.verifyHashStoreRefsFiles(pid, cid, pidRefsFilePath, cidRefsTmpFilePath);
@@ -317,7 +314,7 @@ public class FileHashStoreReferencesTest {
         fileHashStore.tagObject(pid, cid);
 
         // Get path of the cid refs file
-        Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cid, "cid");
 
         String pidAdditional = "dou.test.2";
         fileHashStore.updateRefsFile("dou.test.2", cidRefsFilePath, "add");
@@ -346,7 +343,7 @@ public class FileHashStoreReferencesTest {
         String cid = "abcdef123456789";
         fileHashStore.tagObject(pid, cid);
 
-        Path pidRefsFilePath = fileHashStore.getExpectedPath(pid, "refs", "pid");
+        Path pidRefsFilePath = fileHashStore.getHashStoreRefsPath(pid, "pid");
         fileHashStore.deleteRefsFile(pidRefsFilePath);
 
         assertFalse(Files.exists(pidRefsFilePath));
@@ -360,7 +357,7 @@ public class FileHashStoreReferencesTest {
         String pid = "dou.test.1";
 
         assertThrows(FileNotFoundException.class, () -> {
-            Path pidRefsFilePath = fileHashStore.getExpectedPath(pid, "refs", "pid");
+            Path pidRefsFilePath = fileHashStore.getHashStoreRefsPath(pid, "pid");
             fileHashStore.deleteRefsFile(pidRefsFilePath);
         });
     }
@@ -376,7 +373,7 @@ public class FileHashStoreReferencesTest {
         String pidAdditional = "dou.test.2";
         fileHashStore.tagObject(pidAdditional, cid);
 
-        Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cid, "cid");
         fileHashStore.updateRefsFile(pid, cidRefsFilePath, "remove");
 
         assertFalse(fileHashStore.isStringInRefsFile(pid, cidRefsFilePath));
@@ -393,7 +390,7 @@ public class FileHashStoreReferencesTest {
         fileHashStore.tagObject(pid, cid);
         String pidAdditional = "dou.test.2";
         fileHashStore.tagObject(pidAdditional, cid);
-        Path cidRefsFilePath = fileHashStore.getExpectedPath(cid, "refs", "cid");
+        Path cidRefsFilePath = fileHashStore.getHashStoreRefsPath(cid, "cid");
 
         fileHashStore.updateRefsFile(pid, cidRefsFilePath, "remove");
         fileHashStore.updateRefsFile(pidAdditional, cidRefsFilePath, "remove");

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -419,8 +419,18 @@ public class FileHashStoreReferencesTest {
             long expectedSize = Long.parseLong(testData.pidData.get(pid).get("size"));
 
             fileHashStore.verifyObject(
-                objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, false
+                objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, true
             );
+
+            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
+            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
+            // If cid is found, return the expected real path to object
+            String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
+                storeDepth, storeWidth, objInfo.getCid()
+            );
+            // Real path to the data object
+            assertTrue(Files.exists(Paths.get(fhsProperties.getProperty("storePath")).resolve(
+                "objects").resolve(objRelativePath)));
         }
     }
 
@@ -443,8 +453,18 @@ public class FileHashStoreReferencesTest {
             long expectedSize = Long.parseLong(testData.pidData.get(pid).get("size"));
 
             fileHashStore.verifyObject(
-                objInfo, expectedChecksum, "MD2", expectedSize, false
+                objInfo, expectedChecksum, "MD2", expectedSize, true
             );
+
+            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
+            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
+            // If cid is found, return the expected real path to object
+            String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
+                storeDepth, storeWidth, objInfo.getCid()
+            );
+            // Real path to the data object
+            assertTrue(Files.exists(Paths.get(fhsProperties.getProperty("storePath")).resolve(
+                "objects").resolve(objRelativePath)));
         }
     }
 
@@ -467,6 +487,16 @@ public class FileHashStoreReferencesTest {
                     objInfo, "ValueNotRelevant", "BLAKE2S", 1000, false
                 );
             });
+
+            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
+            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
+            // If cid is found, return the expected real path to object
+            String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
+                storeDepth, storeWidth, objInfo.getCid()
+            );
+            // Real path to the data object
+            assertTrue(Files.exists(Paths.get(fhsProperties.getProperty("storePath")).resolve(
+                "objects").resolve(objRelativePath)));
         }
     }
 
@@ -474,7 +504,7 @@ public class FileHashStoreReferencesTest {
      * Check that verifyObject throws exception when non-matching size value provided
      */
     @Test
-    public void verifyObject_mismatchedValuesNonMatchingSize() throws Exception {
+    public void verifyObject_mismatchedSize() throws Exception {
         for (String pid : testData.pidList) {
             String pidFormatted = pid.replace("/", "_");
             Path testDataFile = testData.getTestFile(pidFormatted);
@@ -494,6 +524,16 @@ public class FileHashStoreReferencesTest {
                     objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, false
                 );
             });
+
+            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
+            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
+            // If cid is found, return the expected real path to object
+            String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
+                storeDepth, storeWidth, objInfo.getCid()
+            );
+            // Real path to the data object
+            assertTrue(Files.exists(Paths.get(fhsProperties.getProperty("storePath")).resolve(
+                "objects").resolve(objRelativePath)));
         }
     }
 
@@ -501,7 +541,7 @@ public class FileHashStoreReferencesTest {
      * Check that verifyObject throws exception with non-matching checksum value
      */
     @Test
-    public void verifyObject_mismatchedValuesNonMatchingChecksum() throws Exception {
+    public void verifyObject_mismatchedChecksum() throws Exception {
         for (String pid : testData.pidList) {
             String pidFormatted = pid.replace("/", "_");
             Path testDataFile = testData.getTestFile(pidFormatted);
@@ -521,6 +561,90 @@ public class FileHashStoreReferencesTest {
                     objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, false
                 );
             });
+
+            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
+            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
+            // If cid is found, return the expected real path to object
+            String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
+                storeDepth, storeWidth, objInfo.getCid()
+            );
+            // Real path to the data object
+            assertTrue(Files.exists(Paths.get(fhsProperties.getProperty("storePath")).resolve(
+                "objects").resolve(objRelativePath)));
+        }
+    }
+
+    /**
+     * Check that verifyObject throws exception when non-matching size value provided
+     */
+    @Test
+    public void verifyObject_mismatchedSize_deleteInvalidObject_true() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
+
+            String defaultStoreAlgorithm = fhsProperties.getProperty("storeAlgorithm");
+
+            // Get verifyObject args
+            String expectedChecksum = testData.pidData.get(pid).get("sha256");
+            long expectedSize = 123456789;
+
+            assertThrows(NonMatchingObjSizeException.class, () -> {
+                fileHashStore.verifyObject(
+                    objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, true
+                );
+            });
+
+            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
+            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
+            // If cid is found, return the expected real path to object
+            String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
+                storeDepth, storeWidth, objInfo.getCid()
+            );
+            // Real path to the data object
+            assertFalse(Files.exists(Paths.get(fhsProperties.getProperty("storePath")).resolve(
+                "objects").resolve(objRelativePath)));
+        }
+    }
+
+    /**
+     * Check that verifyObject throws exception with non-matching checksum value
+     */
+    @Test
+    public void verifyObject_mismatchedChecksum_deleteInvalidObject_true() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+
+            InputStream dataStream = Files.newInputStream(testDataFile);
+            ObjectMetadata objInfo = fileHashStore.storeObject(dataStream);
+            dataStream.close();
+
+            String defaultStoreAlgorithm = fhsProperties.getProperty("storeAlgorithm");
+
+            // Get verifyObject args
+            String expectedChecksum = "intentionallyWrongValue";
+            long expectedSize = Long.parseLong(testData.pidData.get(pid).get("size"));
+
+            assertThrows(NonMatchingChecksumException.class, () -> {
+                fileHashStore.verifyObject(
+                    objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, true
+                );
+            });
+
+            int storeDepth = Integer.parseInt(fhsProperties.getProperty("storeDepth"));
+            int storeWidth = Integer.parseInt(fhsProperties.getProperty("storeWidth"));
+            // If cid is found, return the expected real path to object
+            String objRelativePath = FileHashStoreUtility.getHierarchicalPathString(
+                storeDepth, storeWidth, objInfo.getCid()
+            );
+            // Real path to the data object
+            assertFalse(Files.exists(Paths.get(fhsProperties.getProperty("storePath")).resolve(
+                "objects").resolve(objRelativePath)));
         }
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreReferencesTest.java
@@ -422,7 +422,7 @@ public class FileHashStoreReferencesTest {
             long expectedSize = Long.parseLong(testData.pidData.get(pid).get("size"));
 
             fileHashStore.verifyObject(
-                objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize
+                objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, false
             );
         }
     }
@@ -446,7 +446,7 @@ public class FileHashStoreReferencesTest {
             long expectedSize = Long.parseLong(testData.pidData.get(pid).get("size"));
 
             fileHashStore.verifyObject(
-                objInfo, expectedChecksum, "MD2", expectedSize
+                objInfo, expectedChecksum, "MD2", expectedSize, false
             );
         }
     }
@@ -467,7 +467,7 @@ public class FileHashStoreReferencesTest {
 
             assertThrows(UnsupportedHashAlgorithmException.class, () -> {
                 fileHashStore.verifyObject(
-                    objInfo, "ValueNotRelevant", "BLAKE2S", 1000
+                    objInfo, "ValueNotRelevant", "BLAKE2S", 1000, false
                 );
             });
         }
@@ -494,7 +494,7 @@ public class FileHashStoreReferencesTest {
 
             assertThrows(NonMatchingObjSizeException.class, () -> {
                 fileHashStore.verifyObject(
-                    objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize
+                    objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, false
                 );
             });
         }
@@ -521,7 +521,7 @@ public class FileHashStoreReferencesTest {
 
             assertThrows(NonMatchingChecksumException.class, () -> {
                 fileHashStore.verifyObject(
-                    objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize
+                    objInfo, expectedChecksum, defaultStoreAlgorithm, expectedSize, false
                 );
             });
         }


### PR DESCRIPTION
**Summary of Changes:**
- Updated `verifyObject` signature to include a new boolean value `deleteInvalidObject`
    - When set to true, it will attempt to remove the data object directly (safeguards in place)
- Removed Public API method `deleteObject(String, String)` which was leaking implementation details
- Replaced `getExpectedPath` method with three distinct methods:
    - `getHashStoreDataObjectPath`, `getHashStoreMetadataPath`, `getHashStoreRefsPath`
    - Initially, I kept adding to this `getExpectedPath` as I felt it was the right place to do it - but after reviewing, too much was happening here. If a related-issue occurred, it would not be clear/easy to debug.
- Updated `HashStore` interface javadocs
- `junit` tests have been updated
   