### PR TITLE
Bug-88: `tmpFile` Cleanup

### DIFF
--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1150,7 +1150,7 @@ public class FileHashStore implements HashStore {
             Files.delete(tmpFile.toPath());
             String errMsg =
                 "File already exists for pid: " + pid + ". Object address: " + objRealPath
-                    + ". Deleting temporary file.";
+                    + ". Deleting temporary file: " + tmpFile;
             logFileHashStore.warn(errMsg);
         } else {
             // Move object

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1157,11 +1157,11 @@ public class FileHashStore implements HashStore {
 
         // Confirm that the object does not yet exist, delete tmpFile if so
         if (Files.exists(objRealPath)) {
+            Files.delete(tmpFilePath);
             String errMsg =
                 "File already exists for pid: " + pid + ". Object address: " + objRealPath
                     + ". Deleting temporary file.";
             logFileHashStore.warn(errMsg);
-            Files.delete(tmpFilePath);
         } else {
             // Move object
             File permFile = objRealPath.toFile();

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1105,7 +1105,7 @@ public class FileHashStore implements HashStore {
         AtomicMoveNotSupportedException {
         logFileHashStore.debug("Begin writing data object for pid: " + pid);
         // If validation is desired, checksumAlgorithm and checksum must both be present
-        boolean requestValidation = verifyChecksumParameters(checksum, checksumAlgorithm);
+        boolean compareChecksum = verifyChecksumParameters(checksum, checksumAlgorithm);
         // Validate additional algorithm if not null or empty, throws exception if not supported
         if (additionalAlgorithm != null) {
             FileHashStoreUtility.checkForEmptyString(
@@ -1118,9 +1118,7 @@ public class FileHashStore implements HashStore {
         }
 
         // Generate tmp file and write to it
-        logFileHashStore.debug("Generating tmpFile");
         File tmpFile = FileHashStoreUtility.generateTmpFile("tmp", OBJECT_TMP_FILE_DIRECTORY);
-        Path tmpFilePath = tmpFile.toPath();
         Map<String, String> hexDigests;
         try {
             hexDigests = writeToTmpFileAndGenerateChecksums(
@@ -1128,25 +1126,17 @@ public class FileHashStore implements HashStore {
             );
         } catch (Exception ge) {
             // If the process to write to the tmpFile is interrupted for any reason,
-            // we will delete the tmpFile. 
-            boolean deleteStatus = tmpFile.delete();
-            String errMsg = "Unexpected Exception while storing object for: " + pid;
-            if (deleteStatus) {
-                errMsg = errMsg + ". Deleting temp file: " + tmpFile + ". Aborting request.";
-            } else {
-                errMsg =
-                    errMsg + ". Failed to delete temp file: " + tmpFile + ". Aborting request.";
-            }
+            // we will delete the tmpFile.
+            Files.delete(tmpFile.toPath());
+            String errMsg =
+                "Unexpected Exception while storing object for pid: " + pid + ". " + ge.getMessage();
             logFileHashStore.error(errMsg);
             throw new IOException(errMsg);
         }
-        long storedObjFileSize = Files.size(Paths.get(tmpFile.toString()));
 
         // Validate object if checksum and checksum algorithm is passed
         validateTmpObject(
-            requestValidation, checksum, checksumAlgorithm, tmpFilePath, hexDigests, objSize,
-            storedObjFileSize
-        );
+            compareChecksum, checksum, checksumAlgorithm, tmpFile, hexDigests, objSize);
 
         // Gather the elements to form the permanent address
         String objectCid = hexDigests.get(OBJECT_STORE_ALGORITHM);
@@ -1157,7 +1147,7 @@ public class FileHashStore implements HashStore {
 
         // Confirm that the object does not yet exist, delete tmpFile if so
         if (Files.exists(objRealPath)) {
-            Files.delete(tmpFilePath);
+            Files.delete(tmpFile.toPath());
             String errMsg =
                 "File already exists for pid: " + pid + ". Object address: " + objRealPath
                     + ". Deleting temporary file.";
@@ -1168,16 +1158,17 @@ public class FileHashStore implements HashStore {
             move(tmpFile, permFile, "object");
             logFileHashStore.debug("Successfully moved data object: " + objRealPath);
         }
+        long storedObjFileSize = Files.size(objRealPath);
 
         return new ObjectMetadata(pid, objectCid, storedObjFileSize, hexDigests);
     }
 
     /**
-     * If requestValidation is true, determines the integrity of an object with a given checksum &
+     * If compareChecksum is true, determines the integrity of an object with a given checksum &
      * algorithm against a list of hex digests. If there is a mismatch, the tmpFile will be deleted
      * and exceptions will be thrown.
      *
-     * @param requestValidation Boolean to decide whether to proceed with validation
+     * @param compareChecksum Decide whether to proceed with comparing checksums
      * @param checksum          Expected checksum value of object
      * @param checksumAlgorithm Hash algorithm of checksum value
      * @param tmpFile           Path to the file that is being evaluated
@@ -1187,14 +1178,16 @@ public class FileHashStore implements HashStore {
      * @throws NoSuchAlgorithmException If algorithm requested to validate against is absent
      */
     protected void validateTmpObject(
-        boolean requestValidation, String checksum, String checksumAlgorithm, Path tmpFile,
-        Map<String, String> hexDigests, long expectedSize, long storedObjFileSize
-    ) throws NoSuchAlgorithmException, NonMatchingChecksumException, NonMatchingObjSizeException {
+        boolean compareChecksum, String checksum, String checksumAlgorithm, File tmpFile,
+        Map<String, String> hexDigests, long expectedSize
+    ) throws NoSuchAlgorithmException, NonMatchingChecksumException, NonMatchingObjSizeException,
+        IOException {
         if (expectedSize > 0) {
+            long storedObjFileSize = Files.size(Paths.get(tmpFile.toString()));
             if (expectedSize != storedObjFileSize) {
                 // Delete tmp File
                 try {
-                    Files.delete(tmpFile);
+                    Files.delete(tmpFile.toPath());
 
                 } catch (Exception ge) {
                     String errMsg =
@@ -1214,14 +1207,14 @@ public class FileHashStore implements HashStore {
             }
         }
 
-        if (requestValidation) {
+        if (compareChecksum) {
             logFileHashStore.info("Validating object, checksum arguments supplied and valid.");
             String digestFromHexDigests = hexDigests.get(checksumAlgorithm);
             if (digestFromHexDigests == null) {
                 String baseErrMsg = "Object cannot be validated. Algorithm not found in given "
                     + "hexDigests map. Algorithm requested: " + checksumAlgorithm;
                 try {
-                    Files.delete(tmpFile);
+                    Files.delete(tmpFile.toPath());
                 } catch (Exception ge) {
                     String errMsg = baseErrMsg + ". Failed to delete tmpFile: " + tmpFile + ". "
                         + ge.getMessage();
@@ -1237,7 +1230,7 @@ public class FileHashStore implements HashStore {
                 String baseErrMsg = "Checksum given is not equal to the calculated hex digest: "
                     + digestFromHexDigests + ". Checksum" + " provided: " + checksum;
                 try {
-                    Files.delete(tmpFile);
+                    Files.delete(tmpFile.toPath());
                 } catch (Exception ge) {
                     String errMsg = baseErrMsg + ". Failed to delete tmpFile: " + tmpFile + ". "
                         + ge.getMessage();

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -1960,7 +1960,6 @@ public class FileHashStoreInterfaceTest {
      * Test deleteObject synchronization using a Runnable class
      * TODO: Reactivate with @Test once bug has been investigated
      */
-//    @Disabled
     @Test
     public void deleteObject_1000Pids_1Obj_viaRunnable() throws Exception {
         // Get single test file to "upload"

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -1960,7 +1960,8 @@ public class FileHashStoreInterfaceTest {
      * Test deleteObject synchronization using a Runnable class
      * TODO: Reactivate with @Test once bug has been investigated
      */
-    @Disabled
+//    @Disabled
+    @Test
     public void deleteObject_1000Pids_1Obj_viaRunnable() throws Exception {
         // Get single test file to "upload"
         String pid = "jtao.1700.1";

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -1958,7 +1958,6 @@ public class FileHashStoreInterfaceTest {
 
     /**
      * Test deleteObject synchronization using a Runnable class
-     * TODO: Reactivate with @Test once bug has been investigated
      */
     @Test
     public void deleteObject_1000Pids_1Obj_viaRunnable() throws Exception {
@@ -1968,7 +1967,7 @@ public class FileHashStoreInterfaceTest {
 
         Collection<String> pidModifiedList = new ArrayList<>();
         for (int i = 1; i <= 1000; i++) {
-            pidModifiedList.add(pid + ".dou.test." + i);
+            pidModifiedList.add(pid + ".dou.delobj1k." + i);
         }
 
         Runtime runtime = Runtime.getRuntime();

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -580,9 +581,9 @@ public class FileHashStoreProtectedTest {
         Map<String, String> hexDigests = new HashMap<>();
         hexDigests.put("MD5", "md5Digest");
         hexDigests.put("SHA-256", "sha256Digest");
-        Path tmpFilePath = generateTemporaryFile().toPath();
-        fileHashStore.validateTmpObject(false, "checksum.string", "SHA-256", tmpFilePath,
-                                        hexDigests, -1, 1);
+        File tmpFile = generateTemporaryFile();
+        fileHashStore.validateTmpObject(false, "checksum.string", "SHA-256", tmpFile,
+                                        hexDigests, -1);
     }
 
     /**
@@ -593,9 +594,17 @@ public class FileHashStoreProtectedTest {
         Map<String, String> hexDigests = new HashMap<>();
         hexDigests.put("MD5", "md5Digest");
         hexDigests.put("SHA-256", "sha256Digest");
-        Path tmpFilePath = generateTemporaryFile().toPath();
-        fileHashStore.validateTmpObject(false, "checksum.string", "SHA-256", tmpFilePath,
-                                        hexDigests, 10, 10);
+        File tmpFile = generateTemporaryFile();
+
+        // Write the byte to the file
+        try (FileOutputStream fos = new FileOutputStream(tmpFile)) {
+            fos.write(0x41);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        fileHashStore.validateTmpObject(false, "sha256Digest", "SHA-256", tmpFile,
+                                        hexDigests, 1);
     }
 
     /**
@@ -606,14 +615,14 @@ public class FileHashStoreProtectedTest {
         Map<String, String> hexDigests = new HashMap<>();
         hexDigests.put("MD5", "md5Digest");
         hexDigests.put("SHA-256", "sha256Digest");
-        Path tmpFilePath = generateTemporaryFile().toPath();
+        File tmpFile = generateTemporaryFile();
 
         assertThrows(NonMatchingObjSizeException.class,
                      () -> fileHashStore.validateTmpObject(false, "checksum.string", "SHA-256",
-                                                           tmpFilePath, hexDigests, 10, 20));
+                                                           tmpFile, hexDigests, 10));
     }
 
-    /**
+    /**GG
      * Confirm validateTmpObject does not throw exception when requested to validate checksums
      * with good values
      */
@@ -622,9 +631,9 @@ public class FileHashStoreProtectedTest {
         Map<String, String> hexDigests = new HashMap<>();
         hexDigests.put("MD5", "md5Digest");
         hexDigests.put("SHA-256", "sha256Digest");
-        Path tmpFilePath = generateTemporaryFile().toPath();
-        fileHashStore.validateTmpObject(true, "sha256Digest", "SHA-256", tmpFilePath,
-                                        hexDigests, -1, 1);
+        File tmpFile = generateTemporaryFile();
+        fileHashStore.validateTmpObject(true, "sha256Digest", "SHA-256", tmpFile,
+                                        hexDigests, -1);
     }
 
     /**
@@ -636,12 +645,12 @@ public class FileHashStoreProtectedTest {
         Map<String, String> hexDigests = new HashMap<>();
         hexDigests.put("MD5", "md5Digest");
         hexDigests.put("SHA-256", "sha256Digest");
-        Path tmpFilePath = generateTemporaryFile().toPath();
+        File tmpFile = generateTemporaryFile();
 
         assertThrows(NonMatchingChecksumException.class,
                      () -> fileHashStore.validateTmpObject(true, "checksum.string", "SHA-256",
-                                                           tmpFilePath, hexDigests, -1, -1));
-        assertFalse(Files.exists(tmpFilePath));
+                                                           tmpFile, hexDigests, -1));
+        assertFalse(Files.exists(tmpFile.toPath()));
     }
 
     /**
@@ -653,12 +662,12 @@ public class FileHashStoreProtectedTest {
         Map<String, String> hexDigests = new HashMap<>();
         hexDigests.put("MD5", "md5Digest");
         hexDigests.put("SHA-256", "sha256Digest");
-        Path tmpFilePath = generateTemporaryFile().toPath();
+        File tmpFile = generateTemporaryFile();
 
         assertThrows(NoSuchAlgorithmException.class,
                      () -> fileHashStore.validateTmpObject(true, "md2Digest", "MD2",
-                                                           tmpFilePath, hexDigests, -1, -1));
-        assertFalse(Files.exists(tmpFilePath));
+                                                           tmpFile, hexDigests, -1));
+        assertFalse(Files.exists(tmpFile.toPath()));
     }
 
     /**


### PR DESCRIPTION
**Summary of Changes:**
- Reworked the `storeObject` routine to be more efficient by creating objects only when necessary, removing redundant logging statements, and revising variable names for clarity
- Reactivated failing junit test, added additional details to logging statements and revised affected junit test variables to assist with debugging
