### PR TITLE
Feature-101: 'NonMatchingChecksumException' Declaration

### DIFF
--- a/src/main/java/org/dataone/hashstore/hashstoreconverter/HashStoreConverter.java
+++ b/src/main/java/org/dataone/hashstore/hashstoreconverter/HashStoreConverter.java
@@ -3,6 +3,7 @@ package org.dataone.hashstore.hashstoreconverter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dataone.hashstore.ObjectMetadata;
+import org.dataone.hashstore.exceptions.NonMatchingChecksumException;
 import org.dataone.hashstore.filehashstore.FileHashStoreUtility;
 
 import java.io.IOException;
@@ -61,14 +62,16 @@ public class HashStoreConverter {
      * @param checksum          Value of checksum
      * @param checksumAlgorithm Ex. "SHA-256"
      * @return ObjectMetadata for the given pid
-     * @throws IOException              An issue with calculating checksums or storing sysmeta
-     * @throws NoSuchAlgorithmException An algorithm defined is not supported
-     * @throws InterruptedException     Issue with synchronizing storing metadata
+     * @throws IOException                  An issue with calculating checksums or storing sysmeta
+     * @throws NoSuchAlgorithmException     An algorithm defined is not supported
+     * @throws InterruptedException         Issue with synchronizing storing metadata
+     * @throws NonMatchingChecksumException When the checksums calculated/given do not match
      */
     public ObjectMetadata convert(
         Path filePath, String pid, InputStream sysmetaStream, String checksum,
         String checksumAlgorithm)
-        throws IOException, NoSuchAlgorithmException, InterruptedException {
+        throws IOException, NoSuchAlgorithmException, InterruptedException,
+        NonMatchingChecksumException {
         logHashStoreConverter.info("Begin converting data object and sysmeta for pid: " + pid);
         FileHashStoreUtility.ensureNotNull(sysmetaStream, "sysmetaStream");
         FileHashStoreUtility.ensureNotNull(pid, "pid");

--- a/src/test/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinksTest.java
+++ b/src/test/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinksTest.java
@@ -177,7 +177,7 @@ public class FileHashStoreLinksTest {
     }
 
     /**
-     * Check that storeHardLink creates hard link and returns the correct ObjectMetadata cid
+     * Check that storeHardLink throws nonMatchingChecksumException when values do not match
      */
     @Test
     public void storeHardLink_nonMatchingChecksum() throws Exception {

--- a/src/test/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinksTest.java
+++ b/src/test/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinksTest.java
@@ -180,7 +180,7 @@ public class FileHashStoreLinksTest {
      * Check that storeHardLink throws nonMatchingChecksumException when values do not match
      */
     @Test
-    public void storeHardLink_nonMatchingChecksum() throws Exception {
+    public void storeHardLink_nonMatchingChecksum() {
         for (String pid : testData.pidList) {
             String pidFormatted = pid.replace("/", "_");
             Path testDataFile = testData.getTestFile(pidFormatted);

--- a/src/test/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinksTest.java
+++ b/src/test/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinksTest.java
@@ -1,6 +1,7 @@
 package org.dataone.hashstore.hashstoreconverter;
 
 import org.dataone.hashstore.ObjectMetadata;
+import org.dataone.hashstore.exceptions.NonMatchingChecksumException;
 import org.dataone.hashstore.filehashstore.FileHashStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,8 +17,10 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
 import org.dataone.hashstore.testdata.TestDataHarness;
 
 /**
@@ -56,8 +59,7 @@ public class FileHashStoreLinksTest {
         storeProperties.setProperty("storeWidth", "2");
         storeProperties.setProperty("storeAlgorithm", "SHA-256");
         storeProperties.setProperty(
-            "storeMetadataNamespace", "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
-        );
+            "storeMetadataNamespace", "https://ns.dataone.org/service/types/v2.0#SystemMetadata");
 
         try {
             fileHashStoreLinks = new FileHashStoreLinks(storeProperties);
@@ -123,8 +125,7 @@ public class FileHashStoreLinksTest {
         storeProperties.setProperty("storeWidth", "2");
         storeProperties.setProperty("storeAlgorithm", "SHA-256");
         storeProperties.setProperty(
-            "storeMetadataNamespace", "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
-        );
+            "storeMetadataNamespace", "https://ns.dataone.org/service/types/v2.0#SystemMetadata");
 
         new FileHashStore(storeProperties);
     }
@@ -172,6 +173,23 @@ public class FileHashStoreLinksTest {
 
             fileHashStoreLinks.storeHardLink(testDataFile, pid, sha256, "SHA-256");
             fileHashStoreLinks.storeHardLink(testDataFile, pid + ".test.pid", sha256, "SHA-256");
+        }
+    }
+
+    /**
+     * Check that storeHardLink creates hard link and returns the correct ObjectMetadata cid
+     */
+    @Test
+    public void storeHardLink_nonMatchingChecksum() throws Exception {
+        for (String pid : testData.pidList) {
+            String pidFormatted = pid.replace("/", "_");
+            Path testDataFile = testData.getTestFile(pidFormatted);
+            assertTrue(Files.exists(testDataFile));
+
+            assertThrows(NonMatchingChecksumException.class,
+                         () -> fileHashStoreLinks.storeHardLink(testDataFile, pid, "badchecksum",
+                                                                "SHA-256"));
+
         }
     }
 


### PR DESCRIPTION
**Summary of Changes:**
- HashStoreConverter's `convert` method now specifically declares that a `NonMatchingChecksumException` will be thrown if there is a mismatch
- Added new junit test & apply auto-formatting to junit test class