### PR TITLE
Bug-97: `tagObject` Produces Orphaned Object

### DIFF
--- a/src/main/java/org/dataone/hashstore/exceptions/IdentifierNotLockedException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/IdentifierNotLockedException.java
@@ -1,0 +1,12 @@
+package org.dataone.hashstore.exceptions;
+
+/**
+ * This exception is thrown when an identifier is not locked, breaking thread safety.
+ */
+public class IdentifierNotLockedException extends RuntimeException {
+
+    public IdentifierNotLockedException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1768,14 +1768,7 @@ public class FileHashStore implements HashStore {
                         ". " + e.getMessage());
             }
 
-            try {
-                // Delete all related/relevant items with the least amount of delay
-                FileHashStoreUtility.deleteListItems(deleteList);
-            } catch (Exception e) {
-                logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for request with pid: " + pid + " and cid: " + cid
-                                          + ". " + e.getMessage());
-            }
+            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
             logFileHashStore.info("Untagged pid: " + pid + " with cid: " + cid);
 
         } catch (OrphanPidRefsFileException oprfe) {
@@ -1786,14 +1779,7 @@ public class FileHashStore implements HashStore {
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
 
-            try {
-                // Delete items
-                FileHashStoreUtility.deleteListItems(deleteList);
-            } catch (Exception e) {
-                logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for orphaned pid refs file for pid: " + pid + ". "
-                                          + e.getMessage());
-            }
+            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
             String warnMsg = "Cid refs file does not exist for pid: " + pid
                 + ". Deleted orphan pid refs file.";
             logFileHashStore.warn(warnMsg);
@@ -1848,18 +1834,12 @@ public class FileHashStore implements HashStore {
                         + "refs file for cid: " + cidRead + ". " + e.getMessage());
             }
 
-            try {
-                // Delete all related/relevant items with the least amount of delay
-                FileHashStoreUtility.deleteListItems(deleteList);
-            } catch (Exception e) {
-                logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for request with pid: " + pid + " and cid: " + cid
-                                          + ". " + e.getMessage());
-            }
+            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
             String warnMsg = "Object with cid: " + cidRead
                 + " does not exist, but pid and cid reference file found for pid: " + pid
                 + ". Deleted pid and cid ref files.";
             logFileHashStore.warn(warnMsg);
+
         } catch (PidNotFoundInCidRefsFileException pnficrfe) {
             // `findObject` throws this exception when both the pid and cid refs file exists
             // but the pid is not found in the cid refs file (nothing to change here)
@@ -1869,17 +1849,11 @@ public class FileHashStore implements HashStore {
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
 
-            try {
-                // Delete items
-                FileHashStoreUtility.deleteListItems(deleteList);
-            } catch (Exception e) {
-                logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for request with pid: " + pid + " and cid: " + cid
-                                          + ". " + e.getMessage());
-            }
+            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
             String warnMsg = "Pid not found in expected cid refs file for pid: " + pid
                 + ". Deleted orphan pid refs file.";
             logFileHashStore.warn(warnMsg);
+
         } catch (PidRefsFileNotFoundException prfnfe) {
             // `findObject` throws this exception if the pid refs file is not found
             // Check to see if pid is in the `cid refs file` and attempt to remove it
@@ -1908,6 +1882,25 @@ public class FileHashStore implements HashStore {
                         + "for request with pid: " + pid + " and cid: " + cid + ". "
                         + e.getMessage());
             }
+        }
+    }
+
+    /**
+     * Deletes all the file paths contained in a given 'deleteList'
+     *
+     * @param pid Persistent identifier, used for logging
+     * @param cid Content identifier, used for logging
+     * @param deleteList List of file paths to delete
+     */
+    private static void deleteListOfFilesRenamedForDeletion(
+        String pid, String cid, Collection<Path> deleteList) {
+        try {
+            // Delete all related/relevant items with the least amount of delay
+            FileHashStoreUtility.deleteListItems(deleteList);
+        } catch (Exception e) {
+            logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
+                                      + "for request with pid: " + pid + " and cid: " + cid + ". "
+                                      + e.getMessage());
         }
     }
 

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1749,7 +1749,7 @@ public class FileHashStore implements HashStore {
 
             String warnMsg = "Cid refs file does not exist for pid: " + pid
                 + ". Deleted orphan pid refs file.";
-            logFileHashStore.warn(warnMsg);
+            logFileHashStore.error(warnMsg);
 
         } catch (OrphanRefsFilesException orfe) {
             // `findObject` throws this exception when:
@@ -1768,7 +1768,7 @@ public class FileHashStore implements HashStore {
             String warnMsg = "Object with cid: " + cidToCheck
                 + " does not exist, but pid and cid reference file found for pid: " + pid
                 + ". Deleted pid and cid ref files.";
-            logFileHashStore.warn(warnMsg);
+            logFileHashStore.error(warnMsg);
 
         } catch (PidNotFoundInCidRefsFileException pnficrfe) {
             // `findObject` throws this exception when both the pid and cid refs file exists
@@ -1783,7 +1783,7 @@ public class FileHashStore implements HashStore {
 
             String warnMsg = "Pid not found in expected cid refs file for pid: " + pid
                 + ". Deleted orphan pid refs file.";
-            logFileHashStore.warn(warnMsg);
+            logFileHashStore.error(warnMsg);
 
         } catch (PidRefsFileNotFoundException prfnfe) {
             // `findObject` throws this exception if the pid refs file is not found
@@ -1803,7 +1803,7 @@ public class FileHashStore implements HashStore {
 
             String errMsg =
                 "Pid refs file not found, removed pid from cid refs file for cid: " + cid;
-            logFileHashStore.warn(errMsg);
+            logFileHashStore.error(errMsg);
         }
     }
 
@@ -1855,10 +1855,10 @@ public class FileHashStore implements HashStore {
             } else {
                 String warnMsg = "Cid referenced by pid: " + pid
                     + " is not empty (refs exist for cid). Skipping object " + "deletion.";
-                logFileHashStore.warn(warnMsg);
+                logFileHashStore.error(warnMsg);
             }
         } catch (Exception e) {
-            logFileHashStore.warn(
+            logFileHashStore.error(
                 "Unable to remove pid: " + pid + " from cid refs file: " + absCidRefsPath + ". "
                     + e.getMessage());
         }
@@ -1877,7 +1877,7 @@ public class FileHashStore implements HashStore {
             // Delete all related/relevant items with the least amount of delay
             FileHashStoreUtility.deleteListItems(deleteList);
         } catch (Exception e) {
-            logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
+            logFileHashStore.error("Unable to delete list of refs files marked for deletion "
                                       + "for request with pid: " + pid + " and cid: " + cid + ". "
                                       + e.getMessage());
         }
@@ -1896,7 +1896,7 @@ public class FileHashStore implements HashStore {
             deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
 
         } catch (Exception e) {
-            logFileHashStore.warn(
+            logFileHashStore.error(
                 "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid + "." + " "
                     + e.getMessage());
         }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1749,7 +1749,7 @@ public class FileHashStore implements HashStore {
 
             String warnMsg = "Cid refs file does not exist for pid: " + pid
                 + ". Deleted orphan pid refs file.";
-            logFileHashStore.error(warnMsg);
+            logFileHashStore.warn(warnMsg);
 
         } catch (OrphanRefsFilesException orfe) {
             // `findObject` throws this exception when:
@@ -1768,7 +1768,7 @@ public class FileHashStore implements HashStore {
             String warnMsg = "Object with cid: " + cidToCheck
                 + " does not exist, but pid and cid reference file found for pid: " + pid
                 + ". Deleted pid and cid ref files.";
-            logFileHashStore.error(warnMsg);
+            logFileHashStore.warn(warnMsg);
 
         } catch (PidNotFoundInCidRefsFileException pnficrfe) {
             // `findObject` throws this exception when both the pid and cid refs file exists
@@ -1783,7 +1783,7 @@ public class FileHashStore implements HashStore {
 
             String warnMsg = "Pid not found in expected cid refs file for pid: " + pid
                 + ". Deleted orphan pid refs file.";
-            logFileHashStore.error(warnMsg);
+            logFileHashStore.warn(warnMsg);
 
         } catch (PidRefsFileNotFoundException prfnfe) {
             // `findObject` throws this exception if the pid refs file is not found
@@ -1803,7 +1803,7 @@ public class FileHashStore implements HashStore {
 
             String errMsg =
                 "Pid refs file not found, removed pid from cid refs file for cid: " + cid;
-            logFileHashStore.error(errMsg);
+            logFileHashStore.warn(errMsg);
         }
     }
 
@@ -1855,7 +1855,7 @@ public class FileHashStore implements HashStore {
             } else {
                 String warnMsg = "Cid referenced by pid: " + pid
                     + " is not empty (refs exist for cid). Skipping object " + "deletion.";
-                logFileHashStore.error(warnMsg);
+                logFileHashStore.info(warnMsg);
             }
         } catch (Exception e) {
             logFileHashStore.error(

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1944,9 +1944,7 @@ public class FileHashStore implements HashStore {
                         logFileHashStore.debug(
                             "Ref: " + ref + " already exists in refs file: " + absRefsPath);
                     }
-                }
-
-                if (updateType.equals(HashStoreRefUpdateTypes.remove)) {
+                } else if (updateType.equals(HashStoreRefUpdateTypes.remove)) {
                     lines.remove(ref);
                     Files.write(tmpFilePath, lines, StandardOpenOption.WRITE);
                     move(tmpFile, absRefsPath.toFile(), "refs");

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -550,13 +550,13 @@ public class FileHashStore implements HashStore {
             String errMsg = "pid: " + pid + " already references another cid."
                 + " A pid can only reference one cid.";
             throw new PidRefsFileExistsException(errMsg);
-
-        } catch (Exception e) {
-            // cid and pid has been released
-            // Revert the process for all other exceptions
-            unTagObject(pid, cid);
-            throw e;
         }
+//        } catch (Exception e) {
+//            // cid and pid has been released
+//            // Revert the process for all other exceptions
+//            unTagObject(pid, cid);
+//            throw e;
+//        }
     }
 
     @Override

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1751,14 +1751,7 @@ public class FileHashStore implements HashStore {
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
 
             // Begin deletion process
-            try {
-                deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
-
-            } catch (Exception e) {
-                logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid + "."
-                        + " " + e.getMessage());
-            }
+            addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
 
             try {
                 updateRefsFile(pid, absCidRefsPath, HashStoreRefUpdateTypes.remove);
@@ -1789,15 +1782,9 @@ public class FileHashStore implements HashStore {
             // `findObject` throws this exception when the cid refs file doesn't exist,
             // so we only need to delete the pid refs file (pid is already locked)
             // TODO: Check that the cid found actually matches what has been provided
-            Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
-            try {
-                deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
 
-            } catch (Exception e) {
-                logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid +
-                    ". " + e.getMessage());
-            }
+            Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
+            addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
 
             try {
                 // Delete items
@@ -1841,14 +1828,7 @@ public class FileHashStore implements HashStore {
                 throw new IdentifierNotLockedException(errMsg);
             }
 
-            try {
-                deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
-
-            } catch (Exception e) {
-                logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid + ". "
-                        + e.getMessage());
-            }
+            addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
 
             try {
                 Path absCidRefsPath = getHashStoreRefsPath(cidRead, HashStoreIdTypes.cid);
@@ -1887,14 +1867,7 @@ public class FileHashStore implements HashStore {
 
             // Only rename pid refs file for deletion
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
-            try {
-                deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
-
-            } catch (Exception e) {
-                logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid + "."
-                        + " " + e.getMessage());
-            }
+            addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
 
             try {
                 // Delete items
@@ -1935,6 +1908,25 @@ public class FileHashStore implements HashStore {
                         + "for request with pid: " + pid + " and cid: " + cid + ". "
                         + e.getMessage());
             }
+        }
+    }
+
+    /**
+     * Renames a given path and adds it to a list to delete.
+     *
+     * @param pid            Persistent identifier for exception messaging
+     * @param deleteList     List to add renamed file
+     * @param absPidRefsPath Path of file to rename for deletion
+     */
+    private static void addAndRenamePidRefsFileToDeleteList(
+        String pid, Collection<Path> deleteList, Path absPidRefsPath) {
+        try {
+            deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
+
+        } catch (Exception e) {
+            logFileHashStore.warn(
+                "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid + "." + " "
+                    + e.getMessage());
         }
     }
 

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1934,11 +1934,16 @@ public class FileHashStore implements HashStore {
                 Collection<String> lines = new ArrayList<>(Files.readAllLines(absRefsPath));
 
                 if (updateType.equals(HashStoreRefUpdateTypes.add)) {
-                    lines.add(ref);
-                    Files.write(tmpFilePath, lines, StandardOpenOption.WRITE);
-                    move(tmpFile, absRefsPath.toFile(), "refs");
-                    logFileHashStore.debug(
-                        "Ref: " + ref + " has been added to refs file: " + absRefsPath);
+                    if (!lines.contains(ref)) { // Check for duplicates
+                        lines.add(ref);
+                        Files.write(tmpFilePath, lines, StandardOpenOption.WRITE);
+                        move(tmpFile, absRefsPath.toFile(), "refs");
+                        logFileHashStore.debug(
+                            "Ref: " + ref + " has been added to refs file: " + absRefsPath);
+                    } else {
+                        logFileHashStore.debug(
+                            "Ref: " + ref + " already exists in refs file: " + absRefsPath);
+                    }
                 }
 
                 if (updateType.equals(HashStoreRefUpdateTypes.remove)) {

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1853,9 +1853,9 @@ public class FileHashStore implements HashStore {
             if (Files.size(absCidRefsPath) == 0) {
                 deleteList.add(FileHashStoreUtility.renamePathForDeletion(absCidRefsPath));
             } else {
-                String warnMsg = "Cid referenced by pid: " + pid
+                String infoMsg = "Cid referenced by pid: " + pid
                     + " is not empty (refs exist for cid). Skipping object " + "deletion.";
-                logFileHashStore.info(warnMsg);
+                logFileHashStore.info(infoMsg);
             }
         } catch (Exception e) {
             logFileHashStore.error(

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1731,7 +1731,7 @@ public class FileHashStore implements HashStore {
 
             // Begin deletion process
             addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
-            removePidFromCidRefsAndDetermineDeletion(pid, cid, deleteList);
+            removePidAndHandleCidDeletion(pid, cid, deleteList);
             deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
 
             logFileHashStore.info("Untagged pid: " + pid + " with cid: " + cid);
@@ -1762,7 +1762,7 @@ public class FileHashStore implements HashStore {
 
             // Begin deletion process
             addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
-            removePidFromCidRefsAndDetermineDeletion(pid, cid, deleteList);
+            removePidAndHandleCidDeletion(pid, cid, deleteList);
             deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
 
             String warnMsg = "Object with cid: " + cidToCheck
@@ -1798,7 +1798,7 @@ public class FileHashStore implements HashStore {
                 throw new IdentifierNotLockedException(errMsg);
             }
 
-            removePidFromCidRefsAndDetermineDeletion(pid, cid, deleteList);
+            removePidAndHandleCidDeletion(pid, cid, deleteList);
             deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
 
             String errMsg =
@@ -1844,7 +1844,7 @@ public class FileHashStore implements HashStore {
      * @param cid        Content Identifier
      * @param deleteList If cid refs file needs to be deleted, list to add to
      */
-    private void removePidFromCidRefsAndDetermineDeletion(
+    private void removePidAndHandleCidDeletion(
         String pid, String cid, Collection<Path> deleteList) {
         Path absCidRefsPath = null;
         try {

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1041,10 +1041,11 @@ public class FileHashStore implements HashStore {
      *                                           does not exist.
      * @throws PidNotFoundInCidRefsFileException When pid and cid ref files exists but the expected
      *                                           pid is not found in the cid refs file.
+     * @throws PidRefsFileNotFoundException      When a pid reference file is not found.
      */
     protected ObjectInfo findObject(String pid)
         throws NoSuchAlgorithmException, IOException, OrphanPidRefsFileException,
-        PidNotFoundInCidRefsFileException, OrphanRefsFilesException {
+        PidNotFoundInCidRefsFileException, OrphanRefsFilesException, PidRefsFileNotFoundException {
         logFileHashStore.debug("Finding object for pid: " + pid);
         FileHashStoreUtility.ensureNotNull(pid, "pid");
         FileHashStoreUtility.checkForNotEmptyAndValidString(pid, "pid");

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1723,12 +1723,20 @@ public class FileHashStore implements HashStore {
         // `findObject` which will throw custom exceptions if there is an issue with
         // the reference files, which help us determine the path to proceed with.
         try {
-            findObject(pid);
+            ObjectInfo objInfo = findObject(pid);
+            String cidRetrieved = objInfo.cid();
 
-            // We must confirm that we are working on a cid that is locked
-            // If not, this means that this call is not thread safe.
-            // This `cid` will be released by the calling method.
-            if (!objectLockedCids.contains(cid)) {
+            // If the cid retrieved does not match, this untag request is invalid immediately
+            if (!cid.equals(cidRetrieved)) {
+                String errMsg = "Cid retrieved: " + cidRetrieved + " does not match untag request"
+                    + " cid: " + cid;
+                logFileHashStore.error(errMsg);
+                throw new IdentifierNotLockedException(errMsg);
+
+            } else if (!objectLockedCids.contains(cid)) {
+                // If it matches, we must confirm that we are working on a cid that is locked
+                // If not, this means that this call is not thread safe.
+                // This `cid` will be released by the calling method.
                 String errMsg = "Cannot untag cid that is not currently locked";
                 logFileHashStore.error(errMsg);
                 throw new IdentifierNotLockedException(errMsg);

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1743,7 +1743,8 @@ public class FileHashStore implements HashStore {
 
             } catch (Exception e) {
                 logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid);
+                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid + "."
+                        + " " + e.getMessage());
             }
 
             try {
@@ -1757,7 +1758,8 @@ public class FileHashStore implements HashStore {
                 }
             } catch (Exception e) {
                 logFileHashStore.warn(
-                    "Unable to remove pid: " + pid + " from cid refs file: " + absCidRefsPath);
+                    "Unable to remove pid: " + pid + " from cid refs file: " + absCidRefsPath +
+                        ". " + e.getMessage());
             }
 
             try {
@@ -1765,7 +1767,8 @@ public class FileHashStore implements HashStore {
                 FileHashStoreUtility.deleteListItems(deleteList);
             } catch (Exception e) {
                 logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for request with pid: " + pid + " and cid: " + cid);
+                                          + "for request with pid: " + pid + " and cid: " + cid
+                                          + ". " + e.getMessage());
             }
             logFileHashStore.info("Untagged pid: " + pid + " with cid: " + cid);
 
@@ -1778,7 +1781,8 @@ public class FileHashStore implements HashStore {
 
             } catch (Exception e) {
                 logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid);
+                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid +
+                    ". " + e.getMessage());
             }
 
             try {
@@ -1786,7 +1790,8 @@ public class FileHashStore implements HashStore {
                 FileHashStoreUtility.deleteListItems(deleteList);
             } catch (Exception e) {
                 logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for orphaned pid refs file for pid: " + pid);
+                                          + "for orphaned pid refs file for pid: " + pid + ". "
+                                          + e.getMessage());
             }
             String warnMsg = "Cid refs file does not exist for pid: " + pid
                 + ". Deleted orphan pid refs file.";
@@ -1803,7 +1808,8 @@ public class FileHashStore implements HashStore {
 
             } catch (Exception e) {
                 logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid);
+                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid + ". "
+                        + e.getMessage());
             }
 
             try {
@@ -1820,8 +1826,13 @@ public class FileHashStore implements HashStore {
                     }
                 } catch (Exception e) {
                     logFileHashStore.warn(
-                        "Unable to remove pid: " + pid + " from cid refs file: " + absCidRefsPath);
+                        "Unable to remove pid: " + pid + " from cid refs file: " + absCidRefsPath
+                            + ". " + e.getMessage());
                 }
+            } catch (Exception e ) {
+                logFileHashStore.warn(
+                    "Unexpected exception when attempting to remove pid: " + pid + " from cid "
+                        + "refs file for cid: " + cidRead + ". " + e.getMessage());
             } finally {
                 releaseObjectLockedCids(cidRead);
             }
@@ -1831,7 +1842,8 @@ public class FileHashStore implements HashStore {
                 FileHashStoreUtility.deleteListItems(deleteList);
             } catch (Exception e) {
                 logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for request with pid: " + pid + " and cid: " + cid);
+                                          + "for request with pid: " + pid + " and cid: " + cid
+                                          + ". " + e.getMessage());
             }
             String warnMsg = "Object with cid: " + cidRead
                 + " does not exist, but pid and cid reference file found for pid: " + pid
@@ -1848,7 +1860,8 @@ public class FileHashStore implements HashStore {
 
             } catch (Exception e) {
                 logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid);
+                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid + "."
+                        + " " + e.getMessage());
             }
 
             try {
@@ -1856,7 +1869,8 @@ public class FileHashStore implements HashStore {
                 FileHashStoreUtility.deleteListItems(deleteList);
             } catch (Exception e) {
                 logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for request with pid: " + pid + " and cid: " + cid);
+                                          + "for request with pid: " + pid + " and cid: " + cid
+                                          + ". " + e.getMessage());
             }
             String warnMsg = "Pid not found in expected cid refs file for pid: " + pid
                 + ". Deleted orphan pid refs file.";
@@ -1875,7 +1889,8 @@ public class FileHashStore implements HashStore {
             } catch (Exception e) {
                 logFileHashStore.warn(
                     "Unable to remove pid: " + pid + " from cid refs file: " + absCidRefsPath
-                        + "for request with pid: " + pid + " and cid: " + cid);
+                        + "for request with pid: " + pid + " and cid: " + cid + ". "
+                        + e.getMessage());
             }
         }
     }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -2189,7 +2189,7 @@ public class FileHashStore implements HashStore {
      * @param pid Persistent or authority-based identifier
      * @throws InterruptedException When an issue occurs when attempting to sync the pid
      */
-    private void synchronizeObjectLockedPids(String pid) throws InterruptedException {
+    private static void synchronizeObjectLockedPids(String pid) throws InterruptedException {
         synchronized (objectLockedPids) {
             while (objectLockedPids.contains(pid)) {
                 try {
@@ -2212,7 +2212,7 @@ public class FileHashStore implements HashStore {
      *
      * @param pid Content identifier
      */
-    private void releaseObjectLockedPids(String pid) {
+    private static void releaseObjectLockedPids(String pid) {
         synchronized (objectLockedPids) {
             logFileHashStore.debug("Releasing objectLockedPids for pid: " + pid);
             objectLockedPids.remove(pid);
@@ -2226,7 +2226,7 @@ public class FileHashStore implements HashStore {
      * @param metadataDocId Metadata document id hash(pid+formatId)
      * @throws InterruptedException When an issue occurs when attempting to sync the metadata doc
      */
-    private void synchronizeMetadataLockedDocIds(String metadataDocId)
+    private static void synchronizeMetadataLockedDocIds(String metadataDocId)
         throws InterruptedException {
         synchronized (metadataLockedDocIds) {
             while (metadataLockedDocIds.contains(metadataDocId)) {
@@ -2252,7 +2252,7 @@ public class FileHashStore implements HashStore {
      *
      * @param metadataDocId Metadata document id hash(pid+formatId)
      */
-    private void releaseMetadataLockedDocIds(String metadataDocId) {
+    private static void releaseMetadataLockedDocIds(String metadataDocId) {
         synchronized (metadataLockedDocIds) {
             logFileHashStore.debug(
                 "Releasing metadataLockedDocIds for metadata doc: " + metadataDocId);
@@ -2269,7 +2269,7 @@ public class FileHashStore implements HashStore {
      * @param cid Content identifier
      * @throws InterruptedException When an issue occurs when attempting to sync the pid
      */
-    protected void synchronizeObjectLockedCids(String cid) throws InterruptedException {
+    protected static void synchronizeObjectLockedCids(String cid) throws InterruptedException {
         synchronized (objectLockedCids) {
             while (objectLockedCids.contains(cid)) {
                 try {
@@ -2292,7 +2292,7 @@ public class FileHashStore implements HashStore {
      *
      * @param cid Content identifier
      */
-    protected void releaseObjectLockedCids(String cid) {
+    protected static void releaseObjectLockedCids(String cid) {
         synchronized (objectLockedCids) {
             logFileHashStore.debug("Releasing objectLockedCids for cid: " + cid);
             objectLockedCids.remove(cid);
@@ -2308,7 +2308,7 @@ public class FileHashStore implements HashStore {
      * @param pid Persistent or authority-based identifier
      * @throws InterruptedException When an issue occurs when attempting to sync the pid
      */
-    protected void synchronizeReferenceLockedPids(String pid) throws InterruptedException {
+    protected static void synchronizeReferenceLockedPids(String pid) throws InterruptedException {
         synchronized (referenceLockedPids) {
             while (referenceLockedPids.contains(pid)) {
                 try {
@@ -2331,7 +2331,7 @@ public class FileHashStore implements HashStore {
      *
      * @param pid Persistent or authority-based identifier
      */
-    protected void releaseReferenceLockedPids(String pid) {
+    protected static void releaseReferenceLockedPids(String pid) {
         synchronized (referenceLockedPids) {
             logFileHashStore.debug("Releasing referenceLockedPids for pid: " + pid);
             referenceLockedPids.remove(pid);

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1730,7 +1730,7 @@ public class FileHashStore implements HashStore {
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
 
             // Begin deletion process
-            addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
+            markPidRefsFileForDeletion(pid, deleteList, absPidRefsPath);
             removePidAndHandleCidDeletion(pid, cid, deleteList);
             deleteMarkedFiles(pid, cid, deleteList);
 
@@ -1744,7 +1744,7 @@ public class FileHashStore implements HashStore {
             validateCidAndCheckLocked(pid, cid, cidToCheck);
 
             // Begin deletion process
-            addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
+            markPidRefsFileForDeletion(pid, deleteList, absPidRefsPath);
             deleteMarkedFiles(pid, cid, deleteList);
 
             String warnMsg = "Cid refs file does not exist for pid: " + pid
@@ -1761,7 +1761,7 @@ public class FileHashStore implements HashStore {
             validateCidAndCheckLocked(pid, cid, cidToCheck);
 
             // Begin deletion process
-            addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
+            markPidRefsFileForDeletion(pid, deleteList, absPidRefsPath);
             removePidAndHandleCidDeletion(pid, cid, deleteList);
             deleteMarkedFiles(pid, cid, deleteList);
 
@@ -1778,7 +1778,7 @@ public class FileHashStore implements HashStore {
             validateCidAndCheckLocked(pid, cid, cidToCheck);
 
             // Begin deletion process
-            addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
+            markPidRefsFileForDeletion(pid, deleteList, absPidRefsPath);
             deleteMarkedFiles(pid, cid, deleteList);
 
             String warnMsg = "Pid not found in expected cid refs file for pid: " + pid
@@ -1890,7 +1890,7 @@ public class FileHashStore implements HashStore {
      * @param deleteList     List to add renamed file
      * @param absPidRefsPath Path of file to rename for deletion
      */
-    private static void addAndRenamePidRefsFileToDeleteList(
+    private static void markPidRefsFileForDeletion(
         String pid, Collection<Path> deleteList, Path absPidRefsPath) {
         try {
             deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1627,28 +1627,13 @@ public class FileHashStore implements HashStore {
                     throw new HashStoreRefsAlreadyExistException(errMsg);
 
                 } else if (Files.exists(absPidRefsPath) && !Files.exists(absCidRefsPath)) {
-                    // If pid refs exists, it can only contain and reference one cid
-                    // First, compare the cid retrieved from the pid refs file from the supplied cid
-                    String retrievedCid = new String(Files.readAllBytes(absPidRefsPath));
-                    if (retrievedCid.equalsIgnoreCase(cid)) {
-                        // The pid correctly references the cid, but the cid refs file is missing
-                        // Create the file and verify tagging process
-                        File cidRefsTmpFile = writeRefsFile(pid, HashStoreIdTypes.cid.name());
-                        File absPathCidRefsFile = absCidRefsPath.toFile();
-                        move(cidRefsTmpFile, absPathCidRefsFile, "refs");
-                        verifyHashStoreRefsFiles(pid, cid, absPidRefsPath, absCidRefsPath);
-                        logFileHashStore.info(
-                            "Pid refs file exists for pid: " + pid + ", but cid refs file for: " + cid
-                                + " is missing. Missing cid refs file created and tagging completed.");
-                        return;
-                    } else {
-                        // If a pid is in use, we throw an exception immediately
-                        String errMsg = "Pid refs file already exists for pid: " + pid
-                            + ", and the associated cid refs file contains the "
-                            + "pid. A pid can only reference one cid.";
-                        logFileHashStore.error(errMsg);
-                        throw new PidRefsFileExistsException(errMsg);
-                    }
+                    // If pid refs exists, the pid has already been claimed and cannot be tagged
+                    // We throw an exception immediately
+                    String errMsg = "Pid refs file already exists for pid: " + pid
+                        + ", and the associated cid refs file contains the "
+                        + "pid. A pid can only reference one cid.";
+                    logFileHashStore.error(errMsg);
+                    throw new PidRefsFileExistsException(errMsg);
                 } else if (!Files.exists(absPidRefsPath) && Files.exists(absCidRefsPath)) {
                     // Only update cid refs file if pid is not in the file
                     if (!isStringInRefsFile(pid, absCidRefsPath)) {

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1732,7 +1732,7 @@ public class FileHashStore implements HashStore {
             // Begin deletion process
             addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
             removePidAndHandleCidDeletion(pid, cid, deleteList);
-            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
+            deleteMarkedFiles(pid, cid, deleteList);
 
             logFileHashStore.info("Untagged pid: " + pid + " with cid: " + cid);
 
@@ -1745,7 +1745,7 @@ public class FileHashStore implements HashStore {
 
             // Begin deletion process
             addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
-            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
+            deleteMarkedFiles(pid, cid, deleteList);
 
             String warnMsg = "Cid refs file does not exist for pid: " + pid
                 + ". Deleted orphan pid refs file.";
@@ -1763,7 +1763,7 @@ public class FileHashStore implements HashStore {
             // Begin deletion process
             addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
             removePidAndHandleCidDeletion(pid, cid, deleteList);
-            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
+            deleteMarkedFiles(pid, cid, deleteList);
 
             String warnMsg = "Object with cid: " + cidToCheck
                 + " does not exist, but pid and cid reference file found for pid: " + pid
@@ -1779,7 +1779,7 @@ public class FileHashStore implements HashStore {
 
             // Begin deletion process
             addAndRenamePidRefsFileToDeleteList(pid, deleteList, absPidRefsPath);
-            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
+            deleteMarkedFiles(pid, cid, deleteList);
 
             String warnMsg = "Pid not found in expected cid refs file for pid: " + pid
                 + ". Deleted orphan pid refs file.";
@@ -1799,7 +1799,7 @@ public class FileHashStore implements HashStore {
             }
 
             removePidAndHandleCidDeletion(pid, cid, deleteList);
-            deleteListOfFilesRenamedForDeletion(pid, cid, deleteList);
+            deleteMarkedFiles(pid, cid, deleteList);
 
             String errMsg =
                 "Pid refs file not found, removed pid from cid refs file for cid: " + cid;
@@ -1871,7 +1871,7 @@ public class FileHashStore implements HashStore {
      * @param cid Content identifier, used for logging
      * @param deleteList List of file paths to delete
      */
-    private static void deleteListOfFilesRenamedForDeletion(
+    private static void deleteMarkedFiles(
         String pid, String cid, Collection<Path> deleteList) {
         try {
             // Delete all related/relevant items with the least amount of delay

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1642,20 +1642,12 @@ public class FileHashStore implements HashStore {
                                 + " is missing. Missing cid refs file created and tagging completed.");
                         return;
                     } else {
-                        // Check if the retrieved cid refs file exists and pid is referenced
-                        Path retrievedAbsCidRefsPath =
-                            getHashStoreRefsPath(retrievedCid, HashStoreIdTypes.cid);
-                        if (Files.exists(retrievedAbsCidRefsPath) && isStringInRefsFile(
-                            pid, retrievedAbsCidRefsPath)) {
-                            // This pid is accounted for and tagged as expected.
-                            String errMsg = "Pid refs file already exists for pid: " + pid
-                                + ", and the associated cid refs file contains the "
-                                + "pid. A pid can only reference one cid.";
-                            logFileHashStore.error(errMsg);
-                            throw new PidRefsFileExistsException(errMsg);
-                        }
-                        // Orphaned pid refs file found, the retrieved cid refs file exists
-                        // but doesn't contain the pid. Proceed to overwrite the pid refs file.
+                        // If a pid is in use, we throw an exception immediately
+                        String errMsg = "Pid refs file already exists for pid: " + pid
+                            + ", and the associated cid refs file contains the "
+                            + "pid. A pid can only reference one cid.";
+                        logFileHashStore.error(errMsg);
+                        throw new PidRefsFileExistsException(errMsg);
                     }
                 } else if (!Files.exists(absPidRefsPath) && Files.exists(absCidRefsPath)) {
                     // Only update cid refs file if pid is not in the file

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1730,8 +1730,10 @@ public class FileHashStore implements HashStore {
 
             // If the cid retrieved does not match, this untag request is invalid immediately
             if (!cid.equals(cidRetrieved)) {
-                String errMsg = "Cid retrieved: " + cidRetrieved + " does not match untag request"
-                    + " cid: " + cid;
+                String errMsg =
+                    "Cid retrieved: " + cidRetrieved + " does not match untag request for cid: "
+                        + cid + " and pid: " + pid
+                        + ". Cannot untag cid that is not currently locked.";
                 logFileHashStore.error(errMsg);
                 throw new IdentifierNotLockedException(errMsg);
 
@@ -1739,7 +1741,8 @@ public class FileHashStore implements HashStore {
                 // If it matches, we must confirm that we are working on a cid that is locked
                 // If not, this means that this call is not thread safe.
                 // This `cid` will be released by the calling method.
-                String errMsg = "Cannot untag cid that is not currently locked";
+                String errMsg =
+                    "Cannot untag cid: " + cid + " that is not currently locked (pid: " + pid + ")";
                 logFileHashStore.error(errMsg);
                 throw new IdentifierNotLockedException(errMsg);
             }
@@ -1820,8 +1823,10 @@ public class FileHashStore implements HashStore {
 
             // If the cid retrieved does not match, this untag request is invalid immediately
             if (!cid.equals(cidRead)) {
-                String errMsg = "Cid retrieved: " + cidRead + " does not match untag request"
-                    + " cid: " + cid;
+                String errMsg =
+                    "Orphan reference files found but data object does not exist. Cid read: "
+                        + cidRead + " does not match untag request for cid: " + cid + " and pid: "
+                        + pid + ". Cannot untag cid that is not currently locked.";
                 logFileHashStore.error(errMsg);
                 throw new IdentifierNotLockedException(errMsg);
 
@@ -1829,7 +1834,8 @@ public class FileHashStore implements HashStore {
                 // If it matches, we must confirm that we are working on a cid that is locked
                 // If not, this means that this call is not thread safe.
                 // This `cid` will be released by the calling method.
-                String errMsg = "Cannot untag cid that is not currently locked";
+                String errMsg =
+                    "Cannot untag cid: " + cid + " that is not currently locked (pid: " + pid + ")";
                 logFileHashStore.error(errMsg);
                 throw new IdentifierNotLockedException(errMsg);
             }
@@ -1875,9 +1881,9 @@ public class FileHashStore implements HashStore {
             logFileHashStore.warn(warnMsg);
         } catch (PidNotFoundInCidRefsFileException pnficrfe) {
             // `findObject` throws this exception when both the pid and cid refs file exists
-            // but the pid is not found in the cid refs file.
+            // but the pid is not found in the cid refs file (nothing to change here)
 
-            // Rename pid refs file for deletion
+            // Only rename pid refs file for deletion
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             try {
                 deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1644,14 +1644,14 @@ public class FileHashStore implements HashStore {
                     throw new PidRefsFileExistsException(errMsg);
 
                 } else if (!Files.exists(absPidRefsPath) && Files.exists(absCidRefsPath)) {
-                    // Only update cid refs file if pid is not in the file
-                    if (!isStringInRefsFile(pid, absCidRefsPath)) {
-                        updateRefsFile(pid, absCidRefsPath, HashStoreRefUpdateTypes.add);
-                    }
                     // Get the pid refs file and verify tagging process
                     File pidRefsTmpFile = writeRefsFile(cid, HashStoreIdTypes.pid.name());
                     File absPathPidRefsFile = absPidRefsPath.toFile();
                     move(pidRefsTmpFile, absPathPidRefsFile, "refs");
+                    // Only update cid refs file if pid is not in the file
+                    if (!isStringInRefsFile(pid, absCidRefsPath)) {
+                        updateRefsFile(pid, absCidRefsPath, HashStoreRefUpdateTypes.add);
+                    }
                     verifyHashStoreRefsFiles(pid, cid, absPidRefsPath, absCidRefsPath);
                     logFileHashStore.info("Object with cid: " + cid
                                               + " has been updated and tagged successfully with pid: "

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1718,7 +1718,7 @@ public class FileHashStore implements HashStore {
             throw new IdentifierNotLockedException(errMsg);
         }
 
-        // Before we begin untagging process, we look for the `cid` by calling
+        // Before we begin the untagging process, we look for the `cid` by calling
         // `findObject` which will throw custom exceptions if there is an issue with
         // the reference files, which help us determine the path to proceed with.
         try {
@@ -1740,6 +1740,14 @@ public class FileHashStore implements HashStore {
 
             // Begin deletion process
             try {
+                deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
+
+            } catch (Exception e) {
+                logFileHashStore.warn(
+                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid);
+            }
+
+            try {
                 updateRefsFile(pid, absCidRefsPath, HashStoreRefUpdateTypes.remove);
                 if (Files.size(absCidRefsPath) == 0) {
                     deleteList.add(FileHashStoreUtility.renamePathForDeletion(absCidRefsPath));
@@ -1751,13 +1759,6 @@ public class FileHashStore implements HashStore {
             } catch (Exception e) {
                 logFileHashStore.warn(
                     "Unable to remove pid: " + pid + " from cid refs file: " + absCidRefsPath);
-            }
-
-            try {
-                deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
-            } catch (Exception e) {
-                logFileHashStore.warn(
-                    "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid);
             }
 
             try {
@@ -1775,6 +1776,7 @@ public class FileHashStore implements HashStore {
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             try {
                 deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
+
             } catch (Exception e) {
                 logFileHashStore.warn(
                     "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid);
@@ -1785,7 +1787,7 @@ public class FileHashStore implements HashStore {
                 FileHashStoreUtility.deleteListItems(deleteList);
             } catch (Exception e) {
                 logFileHashStore.warn("Unable to delete list of refs files marked for deletion "
-                                          + "for request with pid: " + pid + " and cid: " + cid);
+                                          + "for orphaned pid refs file for pid: " + pid);
             }
             String warnMsg = "Cid refs file does not exist for pid: " + pid
                 + ". Deleted orphan pid refs file.";
@@ -1842,6 +1844,7 @@ public class FileHashStore implements HashStore {
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             try {
                 deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
+
             } catch (Exception e) {
                 logFileHashStore.warn(
                     "Unable to delete pid refs file: " + absPidRefsPath + " for pid: " + pid);

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1732,10 +1732,9 @@ public class FileHashStore implements HashStore {
             if (!cid.equals(cidRetrieved)) {
                 String errMsg =
                     "Cid retrieved: " + cidRetrieved + " does not match untag request for cid: "
-                        + cid + " and pid: " + pid
-                        + ". Cannot untag cid that is not currently locked.";
+                        + cid + " and pid: " + pid;
                 logFileHashStore.error(errMsg);
-                throw new IdentifierNotLockedException(errMsg);
+                throw new IllegalArgumentException(errMsg);
 
             } else if (!objectLockedCids.contains(cid)) {
                 // If it matches, we must confirm that we are working on a cid that is locked
@@ -1789,6 +1788,7 @@ public class FileHashStore implements HashStore {
         } catch (OrphanPidRefsFileException oprfe) {
             // `findObject` throws this exception when the cid refs file doesn't exist,
             // so we only need to delete the pid refs file (pid is already locked)
+            // TODO: Check that the cid found actually matches what has been provided
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             try {
                 deleteList.add(FileHashStoreUtility.renamePathForDeletion(absPidRefsPath));
@@ -1820,15 +1820,16 @@ public class FileHashStore implements HashStore {
             String cidRead = new String(Files.readAllBytes(absPidRefsPath));
             FileHashStoreUtility.ensureNotNull(cidRead, "cidRead");
             FileHashStoreUtility.checkForNotEmptyAndValidString(cidRead, "cidRead");
+            // TODO: Lots of repeated code with the basic scenario, see how to reduce code length
 
             // If the cid retrieved does not match, this untag request is invalid immediately
             if (!cid.equals(cidRead)) {
                 String errMsg =
                     "Orphan reference files found but data object does not exist. Cid read: "
                         + cidRead + " does not match untag request for cid: " + cid + " and pid: "
-                        + pid + ". Cannot untag cid that is not currently locked.";
+                        + pid;
                 logFileHashStore.error(errMsg);
-                throw new IdentifierNotLockedException(errMsg);
+                throw new IllegalArgumentException(errMsg);
 
             } else if (!objectLockedCids.contains(cid)) {
                 // If it matches, we must confirm that we are working on a cid that is locked
@@ -1882,6 +1883,7 @@ public class FileHashStore implements HashStore {
         } catch (PidNotFoundInCidRefsFileException pnficrfe) {
             // `findObject` throws this exception when both the pid and cid refs file exists
             // but the pid is not found in the cid refs file (nothing to change here)
+            // TODO: Still need to check that the cid found matches
 
             // Only rename pid refs file for deletion
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
@@ -1907,7 +1909,7 @@ public class FileHashStore implements HashStore {
             logFileHashStore.warn(warnMsg);
         } catch (PidRefsFileNotFoundException prfnfe) {
             // `findObject` throws this exception if the pid refs file is not found
-            // Check to see if pid is in the `cid refs file`and attempt to remove it
+            // Check to see if pid is in the `cid refs file` and attempt to remove it
 
             // Confirm that we are working on a cid that is locked
             // If not, this means that this call is not thread safe.

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1725,7 +1725,7 @@ public class FileHashStore implements HashStore {
         try {
             ObjectInfo objInfo = findObject(pid);
             String cidToCheck = objInfo.cid();
-            validateCidAndCheckLocked(pid, cid, cidToCheck);
+            validateAndCheckCidLock(pid, cid, cidToCheck);
 
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
 
@@ -1741,7 +1741,7 @@ public class FileHashStore implements HashStore {
             // so we only need to delete the pid refs file (pid is already locked)
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             String cidToCheck = new String(Files.readAllBytes(absPidRefsPath));
-            validateCidAndCheckLocked(pid, cid, cidToCheck);
+            validateAndCheckCidLock(pid, cid, cidToCheck);
 
             // Begin deletion process
             markPidRefsFileForDeletion(pid, deleteList, absPidRefsPath);
@@ -1758,7 +1758,7 @@ public class FileHashStore implements HashStore {
             // - but the actual object being referenced by the pid does not exist
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             String cidToCheck = new String(Files.readAllBytes(absPidRefsPath));
-            validateCidAndCheckLocked(pid, cid, cidToCheck);
+            validateAndCheckCidLock(pid, cid, cidToCheck);
 
             // Begin deletion process
             markPidRefsFileForDeletion(pid, deleteList, absPidRefsPath);
@@ -1775,7 +1775,7 @@ public class FileHashStore implements HashStore {
             // but the pid is not found in the cid refs file (nothing to change here)
             Path absPidRefsPath = getHashStoreRefsPath(pid, HashStoreIdTypes.pid);
             String cidToCheck = new String(Files.readAllBytes(absPidRefsPath));
-            validateCidAndCheckLocked(pid, cid, cidToCheck);
+            validateAndCheckCidLock(pid, cid, cidToCheck);
 
             // Begin deletion process
             markPidRefsFileForDeletion(pid, deleteList, absPidRefsPath);
@@ -1814,7 +1814,7 @@ public class FileHashStore implements HashStore {
      * @param cid Cid to confirm
      * @param cidToCheck Cid that was retrieved or read
      */
-    private static void validateCidAndCheckLocked(String pid, String cid, String cidToCheck) {
+    private static void validateAndCheckCidLock(String pid, String cid, String cidToCheck) {
         FileHashStoreUtility.ensureNotNull(cidToCheck, "cidToCheck");
         FileHashStoreUtility.checkForNotEmptyAndValidString(cidToCheck, "cidToCheck");
         // If the cid retrieved does not match, this untag request is invalid immediately

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -552,12 +552,6 @@ public class FileHashStore implements HashStore {
                 + " A pid can only reference one cid.";
             throw new PidRefsFileExistsException(errMsg);
         }
-//        } catch (Exception e) {
-//            // cid and pid has been released
-//            // Revert the process for all other exceptions
-//            unTagObject(pid, cid);
-//            throw e;
-//        }
     }
 
     @Override

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -1455,8 +1455,8 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
-     * Check that unTagObject does not throw exception when a pid refs file and cid refs file does
-     * not exist
+     * Check that unTagObject successfully removes a pid from a cid refs file when a pid refs file
+     * is missing but the pid is referenced in a cid refs file
      */
     @Test
     public void unTagObject_missingPidRefsFile() throws Exception {

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -1656,6 +1656,30 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
+     * Confirm that cid refs file does not add duplicate value
+     */
+    @Test
+    public void updateRefsFile_addDuplicateValue() throws Exception {
+        String pid = "dou.test.1";
+        String cid = "abcdef123456789";
+        fileHashStore.tagObject(pid, cid);
+
+        // Get path of the cid refs file
+        Path cidRefsFilePath =
+            fileHashStore.getHashStoreRefsPath(cid, FileHashStore.HashStoreIdTypes.cid);
+
+        String pidAdditional = "dou.test.2";
+        fileHashStore.updateRefsFile(
+            pidAdditional, cidRefsFilePath, FileHashStore.HashStoreRefUpdateTypes.add);
+        // Try re-adding it
+        fileHashStore.updateRefsFile(
+            pidAdditional, cidRefsFilePath, FileHashStore.HashStoreRefUpdateTypes.add);
+
+        List<String> lines = Files.readAllLines(cidRefsFilePath);
+        assertEquals(lines.size(), 2);
+    }
+
+    /**
      * Check that updateRefsFile removes pid from its cid refs file
      */
     @Test

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -1489,6 +1489,68 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
+     * Check that unTagObject successfully deletes cid and pid refs file when a data object does
+     * not exist.
+     */
+    @Test
+    public void unTagObject_refsExistButDataObjectDoesNotExist() throws Exception {
+        String pid = "jtao.1700.1";
+        String cid = testData.pidData.get(pid).get("sha256");
+
+        Collection<String> pidList = new ArrayList<>();
+        for (int i = 1; i < 5; i++) {
+            pidList.add(pid + "." + i);
+        }
+
+        // The object must be stored otherwise the unTag process cannot execute as expected
+        for (String pidToUse : pidList) {
+            fileHashStore.tagObject(pidToUse, cid);
+        }
+
+        String pidToCheck = pid + ".1";
+
+        fileHashStore.synchronizeReferenceLockedPids(pidToCheck);
+        fileHashStore.synchronizeObjectLockedCids(cid);
+
+        fileHashStore.unTagObject(pidToCheck, cid);
+
+        fileHashStore.releaseReferenceLockedPids(pidToCheck);
+        fileHashStore.releaseObjectLockedCids(cid);
+
+        Path absCidRefsPath =
+            fileHashStore.getHashStoreRefsPath(cid, FileHashStore.HashStoreIdTypes.cid);
+        assertFalse(fileHashStore.isStringInRefsFile(pidToCheck, absCidRefsPath));
+    }
+
+    /**
+     * Check that unTagObject successfully deletes cid and pid refs file when a data object does
+     * not exist.
+     */
+    @Test
+    public void unTagObject_refsExistNoObject_singlePidInCidRefs() throws Exception {
+        String pid = "jtao.1700.1";
+        String cid = testData.pidData.get(pid).get("sha256");
+
+        fileHashStore.tagObject(pid, cid);
+
+
+        fileHashStore.synchronizeReferenceLockedPids(pid);
+        fileHashStore.synchronizeObjectLockedCids(cid);
+
+        fileHashStore.unTagObject(pid, cid);
+
+        fileHashStore.releaseReferenceLockedPids(pid);
+        fileHashStore.releaseObjectLockedCids(cid);
+
+        Path absPidRefsPath =
+            fileHashStore.getHashStoreRefsPath(pid, FileHashStore.HashStoreIdTypes.pid);
+        Path absCidRefsPath =
+            fileHashStore.getHashStoreRefsPath(cid, FileHashStore.HashStoreIdTypes.cid);
+        assertFalse(Files.exists(absPidRefsPath));
+        assertFalse(Files.exists(absCidRefsPath));
+    }
+
+    /**
      * Check that no exception is thrown when pid and cid are tagged correctly
      */
     @Test

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -1197,8 +1197,7 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
-     * Check storeHashStoreRefsFiles overwrites an orphaned pid refs file - the 'cid' that it
-     * references does not exist (does not have a cid refs file)
+     * Check storeHashStoreRefsFiles throws exception when a pid refs file already exists
      */
     @Test
     public void storeHashStoreRefsFiles_pidRefsOrphanedFile() throws Exception {
@@ -1214,16 +1213,8 @@ public class FileHashStoreProtectedTest {
         File absPathPidRefsFile = absPidRefsPath.toFile();
         fileHashStore.move(pidRefsTmpFile, absPathPidRefsFile, "refs");
 
-        fileHashStore.storeHashStoreRefsFiles(pid, cid);
-        // There should only be 1 of each ref file
-        Path storePath = Paths.get(fhsProperties.getProperty("storePath"));
-        List<Path> pidRefsFiles =
-            FileHashStoreUtility.getFilesFromDir(storePath.resolve("refs" + "/pids"));
-        List<Path> cidRefsFiles =
-            FileHashStoreUtility.getFilesFromDir(storePath.resolve("refs" + "/cids"));
-
-        assertEquals(1, pidRefsFiles.size());
-        assertEquals(1, cidRefsFiles.size());
+        assertThrows(PidRefsFileExistsException.class,
+                     () -> fileHashStore.storeHashStoreRefsFiles(pid, cid));
     }
 
     /**


### PR DESCRIPTION
**Summary of Changes:**
- `unTagObject` has been extracted from `tagObject` and is now triggered by the actual calling method `storeHashStoreRefsFiles` which may run into an exception and necessitates the call
- `unTagObject`'s synchronization has been removed, and in place of, new guard rails to ensure that the identifiers (pid, cid) are locked before proceeding
    - This will throw a new custom exception (to ensure thread safety): `IdentifierNotLockedException`
- Synchronization methods' access modifiers were changed from private to protected to assist with testing
- junit tests have been updated