### PR TITLE
Feature-108: Default Permissions on HashStore Objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.dataone</groupId>
   <artifactId>hashstore</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1.0</version>
 
   <name>hashstore</name>
   <url>https://github.com/DataONEorg/hashstore-java</url>

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStoreUtility.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStoreUtility.java
@@ -343,7 +343,7 @@ public class FileHashStoreUtility {
         File newTmpFile = newTmpPath.toFile();
 
         // Set default file permissions 'rw- r-- ---' / posix 640
-        Set<PosixFilePermission> permissions = new HashSet<>();
+        final Set<PosixFilePermission> permissions = new HashSet<>();
         permissions.add(PosixFilePermission.OWNER_READ);
         permissions.add(PosixFilePermission.OWNER_WRITE);
         permissions.add(PosixFilePermission.GROUP_READ);

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStoreUtility.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStoreUtility.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,9 +17,11 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.xml.bind.DatatypeConverter;
@@ -336,10 +339,19 @@ public class FileHashStoreUtility {
         int randomNumber = rand.nextInt(1000000);
         String newPrefix = prefix + "-" + System.currentTimeMillis() + randomNumber;
 
-        Path newPath = Files.createTempFile(directory, newPrefix, null);
-        File newFile = newPath.toFile();
-        newFile.deleteOnExit();
-        return newFile;
+        Path newTmpPath = Files.createTempFile(directory, newPrefix, null);
+        File newTmpFile = newTmpPath.toFile();
+
+        // Set default file permissions 'rw- r-- ---' / posix 640
+        Set<PosixFilePermission> permissions = new HashSet<>();
+        permissions.add(PosixFilePermission.OWNER_READ);
+        permissions.add(PosixFilePermission.OWNER_WRITE);
+        permissions.add(PosixFilePermission.GROUP_READ);
+        Files.setPosixFilePermissions(newTmpPath, permissions);
+        // Mark tmp file to be cleaned up if it runs into an issue
+        newTmpFile.deleteOnExit();
+
+        return newTmpFile;
     }
 
     /**

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStoreUtility.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStoreUtility.java
@@ -324,8 +324,9 @@ public class FileHashStoreUtility {
     }
 
     /**
-     * Creates an empty/temporary file in a given location. If this file is not moved, it will be
-     * deleted upon JVM gracefully exiting or shutting down.
+     * Creates an empty/temporary file in a given location. This temporary file has the default
+     * permissions of 'rw- r-- ---'  (owner read/write, and group read). If this file is not
+     * moved, it will be deleted upon JVM gracefully exiting or shutting down.
      *
      * @param prefix    string to prepend before tmp file
      * @param directory location to create tmp file
@@ -342,7 +343,7 @@ public class FileHashStoreUtility {
         Path newTmpPath = Files.createTempFile(directory, newPrefix, null);
         File newTmpFile = newTmpPath.toFile();
 
-        // Set default file permissions 'rw- r-- ---' / posix 640
+        // Set default file permissions 'rw- r-- ---'
         final Set<PosixFilePermission> permissions = new HashSet<>();
         permissions.add(PosixFilePermission.OWNER_READ);
         permissions.add(PosixFilePermission.OWNER_WRITE);

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -187,6 +187,12 @@ public class FileHashStoreInterfaceTest {
                 Set<PosixFilePermission> actualPermissions = Files.getPosixFilePermissions(objRealPath);
 
                 assertEquals(expectedPermissions, actualPermissions);
+                assertFalse(actualPermissions.contains(PosixFilePermission.OWNER_EXECUTE));
+                assertFalse(actualPermissions.contains(PosixFilePermission.GROUP_WRITE));
+                assertFalse(actualPermissions.contains(PosixFilePermission.GROUP_EXECUTE));
+                assertFalse(actualPermissions.contains(PosixFilePermission.OTHERS_READ));
+                assertFalse(actualPermissions.contains(PosixFilePermission.OTHERS_WRITE));
+                assertFalse(actualPermissions.contains(PosixFilePermission.OTHERS_EXECUTE));
             }
         }
     }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -184,7 +184,8 @@ public class FileHashStoreInterfaceTest {
                 expectedPermissions.add(PosixFilePermission.OWNER_WRITE);
                 expectedPermissions.add(PosixFilePermission.GROUP_READ);
 
-                Set<PosixFilePermission> actualPermissions = Files.getPosixFilePermissions(objRealPath);
+                Set<PosixFilePermission> actualPermissions =
+                    Files.getPosixFilePermissions(objRealPath);
 
                 assertEquals(expectedPermissions, actualPermissions);
                 assertFalse(actualPermissions.contains(PosixFilePermission.OWNER_EXECUTE));

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -2430,7 +2430,7 @@ public class FileHashStoreProtectedTest {
      * Confirm that generateTemporaryFile creates tmpFile with expected permissions
      */
     @Test
-    public void fileHashStoreUtility_generateTemporaryFile_permissions() throws Exception {
+    public void fileHashStoreUtility_generateTmpFile_permissions() throws Exception {
         Path directory = tempFolder.resolve("hashstore");
         // newFile
         File tmpFile = FileHashStoreUtility.generateTmpFile("testfile", directory);

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -2440,7 +2440,8 @@ public class FileHashStoreProtectedTest {
         expectedPermissions.add(PosixFilePermission.OWNER_WRITE);
         expectedPermissions.add(PosixFilePermission.GROUP_READ);
 
-        Set<PosixFilePermission> actualPermissions = Files.getPosixFilePermissions(tmpFile.toPath());
+        Set<PosixFilePermission> actualPermissions =
+            Files.getPosixFilePermissions(tmpFile.toPath());
 
         assertEquals(expectedPermissions, actualPermissions);
         assertFalse(actualPermissions.contains(PosixFilePermission.OWNER_EXECUTE));

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -15,15 +15,18 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -2420,5 +2423,25 @@ public class FileHashStoreProtectedTest {
                 assertTrue(Files.exists(metadataPath));
             }
         }
+    }
+
+
+    /**
+     * Confirm that generateTemporaryFile creates tmpFile with expected permissions
+     */
+    @Test
+    public void fileHashStoreUtility_generateTemporaryFile_permissions() throws Exception {
+        Path directory = tempFolder.resolve("hashstore");
+        // newFile
+        File tmpFile = FileHashStoreUtility.generateTmpFile("testfile", directory);
+
+        Collection<PosixFilePermission> expectedPermissions = new HashSet<>();
+        expectedPermissions.add(PosixFilePermission.OWNER_READ);
+        expectedPermissions.add(PosixFilePermission.OWNER_WRITE);
+        expectedPermissions.add(PosixFilePermission.GROUP_READ);
+
+        Set<PosixFilePermission> actualPermissions = Files.getPosixFilePermissions(tmpFile.toPath());
+
+        assertEquals(expectedPermissions, actualPermissions);
     }
 }

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -2443,5 +2443,11 @@ public class FileHashStoreProtectedTest {
         Set<PosixFilePermission> actualPermissions = Files.getPosixFilePermissions(tmpFile.toPath());
 
         assertEquals(expectedPermissions, actualPermissions);
+        assertFalse(actualPermissions.contains(PosixFilePermission.OWNER_EXECUTE));
+        assertFalse(actualPermissions.contains(PosixFilePermission.GROUP_WRITE));
+        assertFalse(actualPermissions.contains(PosixFilePermission.GROUP_EXECUTE));
+        assertFalse(actualPermissions.contains(PosixFilePermission.OTHERS_READ));
+        assertFalse(actualPermissions.contains(PosixFilePermission.OTHERS_WRITE));
+        assertFalse(actualPermissions.contains(PosixFilePermission.OTHERS_EXECUTE));
     }
 }


### PR DESCRIPTION
**Summary of Changes:**
- FileHashStoreUtility's `generateTmpFile` method now sets default permissions on each temporary file generated (`rw- r-- ---`)
- Added new junit tests to confirm permissions are set and persist