### PR TITLE
Feature-114: NonMatchingChecksumException hexDigests Inclusion

### DIFF
--- a/src/main/java/org/dataone/hashstore/exceptions/NonMatchingChecksumException.java
+++ b/src/main/java/org/dataone/hashstore/exceptions/NonMatchingChecksumException.java
@@ -1,13 +1,21 @@
 package org.dataone.hashstore.exceptions;
 
+import java.util.Map;
+
 /**
  * An exception thrown when a checksum does not match what is expected.
  */
 
 public class NonMatchingChecksumException extends IllegalArgumentException {
 
-    public NonMatchingChecksumException(String message) {
+    private final Map<String, String> hexDigests;
+
+    public NonMatchingChecksumException(String message, Map<String, String> checksumMap) {
         super(message);
+        this.hexDigests = checksumMap;
     }
 
+    public Map<String, String> getHexDigests() {
+        return hexDigests;
+    }
 }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -859,7 +859,7 @@ public class FileHashStore implements HashStore {
                     + ". Actual checksum calculated: " + digestFromHexDigests + " (algorithm: "
                     + checksumAlgorithm + ")";
             logFileHashStore.error(errMsg);
-            throw new NonMatchingChecksumException(errMsg);
+            throw new NonMatchingChecksumException(errMsg, hexDigests);
         }
         // Validate size
         if (objInfoRetrievedSize != objSize) {
@@ -1269,7 +1269,7 @@ public class FileHashStore implements HashStore {
                     String errMsg = baseErrMsg + ". Failed to delete tmpFile: " + tmpFile + ". "
                         + ge.getMessage();
                     logFileHashStore.error(errMsg);
-                    throw new NonMatchingChecksumException(errMsg);
+                    throw new NonMatchingChecksumException(errMsg, hexDigests);
                 }
                 String errMsg = baseErrMsg + ". tmpFile has been deleted: " + tmpFile;
                 logFileHashStore.error(errMsg);
@@ -1285,12 +1285,12 @@ public class FileHashStore implements HashStore {
                     String errMsg = baseErrMsg + ". Failed to delete tmpFile: " + tmpFile + ". "
                         + ge.getMessage();
                     logFileHashStore.error(errMsg);
-                    throw new NonMatchingChecksumException(errMsg);
+                    throw new NonMatchingChecksumException(errMsg, hexDigests);
                 }
 
                 String errMsg = baseErrMsg + ". tmpFile has been deleted: " + tmpFile;
                 logFileHashStore.error(errMsg);
-                throw new NonMatchingChecksumException(errMsg);
+                throw new NonMatchingChecksumException(errMsg, hexDigests);
             }
         }
     }

--- a/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
+++ b/src/main/java/org/dataone/hashstore/filehashstore/FileHashStore.java
@@ -1258,6 +1258,7 @@ public class FileHashStore implements HashStore {
         }
 
         if (compareChecksum) {
+            FileHashStoreUtility.ensureNotNull(hexDigests, "hexDigests");
             logFileHashStore.info("Validating object, checksum arguments supplied and valid.");
             String digestFromHexDigests = hexDigests.get(checksumAlgorithm);
             if (digestFromHexDigests == null) {

--- a/src/main/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinks.java
+++ b/src/main/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinks.java
@@ -100,7 +100,7 @@ public class FileHashStoreLinks extends FileHashStore {
                     + " calculated: " + checksumToMatch + " for pid: " + pid + " and checksum"
                     + " algorithm: " + checksumAlgorithm;
                 logFileHashStoreLinks.error(errMsg);
-                throw new NonMatchingChecksumException(errMsg);
+                throw new NonMatchingChecksumException(errMsg, hexDigests);
             }
 
             // Gather the elements to form the permanent address

--- a/src/main/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinks.java
+++ b/src/main/java/org/dataone/hashstore/hashstoreconverter/FileHashStoreLinks.java
@@ -94,6 +94,7 @@ public class FileHashStoreLinks extends FileHashStore {
 
         try (InputStream fileStream = Files.newInputStream(filePath)) {
             Map<String, String> hexDigests = generateChecksums(fileStream, checksumAlgorithm);
+            FileHashStoreUtility.ensureNotNull(hexDigests, "hexDigests");
             String checksumToMatch = hexDigests.get(checksumAlgorithm);
             if (!checksum.equalsIgnoreCase(checksumToMatch)) {
                 String errMsg = "Checksum supplied: " + checksum + " does not match what has been"

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreInterfaceTest.java
@@ -365,7 +365,7 @@ public class FileHashStoreInterfaceTest {
      */
     @Test
     public void storeObject_incorrectChecksumValue() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(NonMatchingChecksumException.class, () -> {
             // Get test file to "upload"
             String pid = "jtao.1700.1";
             Path testDataFile = testData.getTestFile(pid);
@@ -377,6 +377,39 @@ public class FileHashStoreInterfaceTest {
                 fileHashStore.storeObject(dataStream, pid, null, checksumIncorrect, "SHA-256", -1);
             }
         });
+    }
+
+    /**
+     * Verify exception contains hexDigests when NonMatchingChecksumException is thrown
+     */
+    @Test
+    public void storeObject_nonMatchingChecksumException_hexDigestsIncluded() throws Exception {
+        // Get test file to "upload"
+        String pid = "jtao.1700.1";
+        Path testDataFile = testData.getTestFile(pid);
+
+        String checksumIncorrect =
+            "aaf9b6c88f1f458e410c30c351c6384ea42ac1b5ee1f8430d3e365e43b78a38a";
+
+        try (InputStream dataStream = Files.newInputStream(testDataFile)) {
+            try {
+                fileHashStore.storeObject(dataStream, pid, null, checksumIncorrect, "SHA-256", -1);
+
+            } catch (NonMatchingChecksumException nmce) {
+                Map<String, String> hexDigestsRetrieved = nmce.getHexDigests();
+
+                String md5 = testData.pidData.get(pid).get("md5");
+                String sha1 = testData.pidData.get(pid).get("sha1");
+                String sha256 = testData.pidData.get(pid).get("sha256");
+                String sha384 = testData.pidData.get(pid).get("sha384");
+                String sha512 = testData.pidData.get(pid).get("sha512");
+                assertEquals(md5, hexDigestsRetrieved.get("MD5"));
+                assertEquals(sha1, hexDigestsRetrieved.get("SHA-1"));
+                assertEquals(sha256, hexDigestsRetrieved.get("SHA-256"));
+                assertEquals(sha384, hexDigestsRetrieved.get("SHA-384"));
+                assertEquals(sha512, hexDigestsRetrieved.get("SHA-512"));
+            }
+        }
     }
 
     /**

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -643,8 +643,8 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
-     * Confirm validateTmpObject does not throw exception when requested to validate checksums with
-     * good values, and that the tmpFile passed is deleted.
+     * Confirm validateTmpObject throws exception when requested to validate a bad checksum,
+     * and that the tmpFile passed is deleted.
      */
     @Test
     public void validateTmpObject_validationRequested_nonMatchingChecksum() throws Exception {

--- a/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
+++ b/src/test/java/org/dataone/hashstore/filehashstore/FileHashStoreProtectedTest.java
@@ -677,6 +677,18 @@ public class FileHashStoreProtectedTest {
     }
 
     /**
+     * Confirm validateTmpObject throws exception when hexDigests provided is null
+     */
+    @Test
+    public void validateTmpObject_validationRequested_hexDigestsNull() throws Exception {
+        File tmpFile = generateTemporaryFile();
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> fileHashStore.validateTmpObject(true, "md2Digest", "MD2", tmpFile, null,
+                                                           -1));
+    }
+
+    /**
      * Check algorithm support for supported algorithm
      */
     @Test


### PR DESCRIPTION
**Summary of Changes:**
- When a `NonMatchingChecksumException` exception is thrown, the hexDigests calculated during the process is included as an attribute of the `NonMatchingChecksumException` class, and a new method `getHexDigests` can be called to retrieve the calculated list.